### PR TITLE
이메일 변경 

### DIFF
--- a/src/main/java/today/todaysentence/domain/member/Member.java
+++ b/src/main/java/today/todaysentence/domain/member/Member.java
@@ -27,16 +27,18 @@ public class Member extends Timestamped {
     private String password;
 
     @Column(nullable = false,unique = true)
-    @Setter
     private String nickname;
 
-    @Setter
     @Builder.Default
     private String statusMessage = "상태메시지를 입력해주세요.";
 
     @Column(name = "nickname_updated_at")
     @Builder.Default
     private LocalDateTime nicknameUpdatedAt = LocalDateTime.now();
+
+    @Column(name = "email_updated_at")
+    @Builder.Default
+    private LocalDateTime emailUpdatedAt = LocalDateTime.now();
 
     @Column(name = "password_updated_at")
     @Builder.Default
@@ -64,5 +66,13 @@ public class Member extends Timestamped {
         this.nickname+="_W_"+UUID.randomUUID().toString();
         this.setDeletedAt(LocalDateTime.now());
     }
+    public void changeEmail(String email){
+        this.email = email;
+    }public void changeNickname(String nickname){
+        this.nickname = nickname;
+    }public void changeMessage(String message){
+        this.statusMessage = message;
+    }
+
 
 }

--- a/src/main/java/today/todaysentence/domain/member/Member.java
+++ b/src/main/java/today/todaysentence/domain/member/Member.java
@@ -66,11 +66,16 @@ public class Member extends Timestamped {
         this.nickname+="_W_"+UUID.randomUUID().toString();
         this.setDeletedAt(LocalDateTime.now());
     }
+
     public void changeEmail(String email){
         this.email = email;
-    }public void changeNickname(String nickname){
+    }
+
+    public void changeNickname(String nickname){
         this.nickname = nickname;
-    }public void changeMessage(String message){
+    }
+
+    public void changeMessage(String message){
         this.statusMessage = message;
     }
 

--- a/src/main/java/today/todaysentence/domain/member/api/MemberController.java
+++ b/src/main/java/today/todaysentence/domain/member/api/MemberController.java
@@ -74,11 +74,19 @@ public class MemberController implements MemberApiSpec {
     }
 
     @Override
+    @PutMapping("/change-email")
+    public CommonResponse<?> changeEmail(@AuthenticationPrincipal CustomUserDetails userDetails,
+                                         @RequestBody MemberRequest.CheckEmail email) {
+        return memberService.changeEmail(userDetails, email.email());
+    }
+
+    @Override
     @PutMapping("/change-message")
     public CommonResponse<?> changeMessage(@AuthenticationPrincipal CustomUserDetails userDetails,
                                            @RequestBody @Valid MemberRequest.CheckMessage message) {
         return memberService.changeMessage(userDetails,message);
     }
+
 
     @Override
     @PostMapping("/find-email")

--- a/src/main/java/today/todaysentence/domain/member/service/MemberService.java
+++ b/src/main/java/today/todaysentence/domain/member/service/MemberService.java
@@ -227,6 +227,7 @@ public class MemberService {
 
 
 
+    @Transactional
     private CommonResponse<?> changeField(Member member, String type, String field){
 
         LocalDateTime changedTime = switch (type) {
@@ -235,9 +236,6 @@ public class MemberService {
             case EMAIL_TYPE -> member.getEmailUpdatedAt();
             default -> throw new BaseException(ExceptionCode.PARAMETER_VALIDATION_FAIL);
         };
-        if (changedTime == null) {
-            changedTime = member.getCreateAt(); // 기본값을 설정
-        }
 
         long daysBetween = calculateDaysBetween(changedTime,LocalDateTime.now());
 
@@ -248,6 +246,7 @@ public class MemberService {
                 case EMAIL_TYPE -> member.changeEmail(field);
             }
             memberRepository.save(member);
+
             return CommonResponse.ok(new MemberResponse.MemberInfo(member));
         } else {
 
@@ -261,6 +260,7 @@ public class MemberService {
     private long calculateDaysBetween(LocalDateTime startDate, LocalDateTime endDate) {
         return Duration.between(startDate.withSecond(0).withNano(0), endDate.withSecond(0).withNano(0)).toDays();
     }
+
     @Transactional(readOnly = true)
     public void checkEmail(String email) {
 
@@ -286,7 +286,6 @@ public class MemberService {
         }
 
     }
-
 
     private CommonResponse<?> registerNewMember(MemberRequest.SignUp signUpRequest) {
 

--- a/src/main/java/today/todaysentence/global/swagger/MemberApiSpec.java
+++ b/src/main/java/today/todaysentence/global/swagger/MemberApiSpec.java
@@ -231,6 +231,18 @@ public interface MemberApiSpec {
     })
     CommonResponse<?> changePassword(CustomUserDetails userDetails, MemberRequest.CheckPassword password);
 
+    @Operation(summary = "회원정보 변경 - 이메일 변경")
+    @ApiResponses({
+            @ApiResponse(responseCode = "200", content = @Content(mediaType = "application/json", examples = {
+                    @ExampleObject(name = "이메일 변경 성공", value = """
+                            {
+                                "success" : true
+                            }
+                            """)
+            }))
+    })
+    CommonResponse<?> changeEmail(CustomUserDetails userDetails, MemberRequest.CheckEmail email);
+
     @Operation(summary = "회원정보 변경 - 상태메시지 변경")
     @ApiResponses({
             @ApiResponse(responseCode = "200", content = @Content(mediaType = "application/json", examples = {


### PR DESCRIPTION
기존의 메시지, 닉네임 처럼 이메일변경도 추가하였습니다.

추가하면서 Member 엔티티의 setter대신 메서드로 변경했습니다.

서비스로직의 삼항연산자와 if else를 switch case로 변경했습니다.

