### PR TITLE
Feature todaysentence

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -62,6 +62,9 @@ dependencies {
     //email
     implementation 'org.springframework.boot:spring-boot-starter-mail'
 
+    implementation 'com.fasterxml.jackson.datatype:jackson-datatype-jsr310'
+
+
 
 
 }

--- a/src/main/java/today/todaysentence/TodaySentenceApplication.java
+++ b/src/main/java/today/todaysentence/TodaySentenceApplication.java
@@ -3,6 +3,7 @@ package today.todaysentence;
 import jakarta.annotation.PostConstruct;
 import org.springframework.boot.SpringApplication;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
+import org.springframework.cache.annotation.EnableCaching;
 import org.springframework.context.annotation.EnableAspectJAutoProxy;
 import org.springframework.data.jpa.repository.config.EnableJpaAuditing;
 import org.springframework.scheduling.annotation.EnableScheduling;
@@ -13,6 +14,7 @@ import java.util.TimeZone;
 @SpringBootApplication
 @EnableAspectJAutoProxy
 @EnableJpaAuditing
+@EnableCaching
 public class TodaySentenceApplication {
 
     public static void main(String[] args) {

--- a/src/main/java/today/todaysentence/domain/hashtag/repository/HashtagRepository.java
+++ b/src/main/java/today/todaysentence/domain/hashtag/repository/HashtagRepository.java
@@ -2,6 +2,7 @@ package today.todaysentence.domain.hashtag.repository;
 
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
 import today.todaysentence.domain.hashtag.Hashtag;
 
 import java.util.List;
@@ -13,4 +14,13 @@ public interface HashtagRepository extends JpaRepository<Hashtag, Long> {
 
     @Query("SELECT h FROM Hashtag h")
     List<Hashtag> findAllName();
+
+
+    @Query("SELECT h FROM Hashtag h")
+    List<Hashtag> findAllIds();
+
+    @Query("SELECT h FROM Hashtag h WHERE h.id NOT IN :hashIds")
+    List<Hashtag> findNewIds(@Param("hashIds") List<Long> hashIdsLong);
+
+
 }

--- a/src/main/java/today/todaysentence/domain/post/api/PostController.java
+++ b/src/main/java/today/todaysentence/domain/post/api/PostController.java
@@ -16,6 +16,7 @@ import org.springframework.web.bind.annotation.RestController;
 import today.todaysentence.domain.member.Member;
 import today.todaysentence.domain.post.dto.PostRequest;
 import today.todaysentence.domain.post.dto.PostResponse;
+import today.todaysentence.domain.post.dto.PostResponseDTO;
 import today.todaysentence.domain.post.service.PostService;
 import today.todaysentence.global.response.CommonResponse;
 import today.todaysentence.global.security.userDetails.CustomUserDetails;
@@ -60,5 +61,12 @@ public class PostController implements PostApiSpec {
     public CommonResponse<PostResponse.Statistics> getStatistics(@AuthenticationPrincipal CustomUserDetails userDetails){
         return postService.getStatistics(userDetails);
     }
+
+    @GetMapping("/today-sentence")
+    public CommonResponse<PostResponseDTO> getTodaySentence(@AuthenticationPrincipal CustomUserDetails userDetails){
+        return postService.getTodaySentence(userDetails);
+    }
+
+
 
 }

--- a/src/main/java/today/todaysentence/domain/post/dto/PostResponseDTO.java
+++ b/src/main/java/today/todaysentence/domain/post/dto/PostResponseDTO.java
@@ -1,0 +1,42 @@
+package today.todaysentence.domain.post.dto;
+
+
+import com.fasterxml.jackson.annotation.JsonFormat;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
+import today.todaysentence.domain.post.Post;
+
+import java.time.LocalDateTime;
+
+@Getter
+@Setter
+@NoArgsConstructor
+@AllArgsConstructor
+public class PostResponseDTO {
+
+    String bookTitle;
+    String bookAuthor;
+    String bookCover;
+    String bookPublisher;
+    Integer bookPublishingYear;
+
+    //post
+    Long postId;
+    String postWriter;
+    String postContent;
+    String category;
+    String hashtags;
+    String createAt;
+
+    //counts
+    Long likesCount;
+    Long bookmarkCount;
+    Long commentCount;
+
+
+
+
+
+}

--- a/src/main/java/today/todaysentence/domain/post/repository/PostRepository.java
+++ b/src/main/java/today/todaysentence/domain/post/repository/PostRepository.java
@@ -8,7 +8,6 @@ import org.springframework.lang.NonNull;
 import today.todaysentence.domain.member.Member;
 import today.todaysentence.domain.post.Post;
 import today.todaysentence.domain.post.dto.PostResponse;
-import today.todaysentence.domain.search.dto.SearchResponse;
 
 import java.time.LocalDateTime;
 import java.util.List;
@@ -23,79 +22,6 @@ public interface PostRepository extends JpaRepository<Post, Long> {
                                  @Param("endDate") LocalDateTime endDate);
 
     Optional<Post> findById(@NonNull Long id);
-
-    @Query(value = "SELECT " +
-            "b.title , b.author , b.cover, b.publisher, b.publishing_year, " +
-            "p.id , m.nickname, p.content, p.category , " +
-            "GROUP_CONCAT(DISTINCT h.name), " +
-            "CAST(p.create_at AS CHAR) AS create_at, " +
-            "COUNT(l.id) as like_count, " +
-            "COUNT(bm.id) as bookmark_count " +
-            "FROM post p " +
-            "INNER JOIN member m ON m.id = p.writer_id " +
-            "INNER JOIN book b ON b.isbn = p.book_isbn " +
-            "INNER JOIN post_hashtag ph ON ph.post_id = p.id " +
-            "LEFT JOIN likes l ON l.post_id = p.id " +
-            "LEFT JOIN bookmark bm ON bm.post_id = p.id " +
-            "LEFT JOIN hashtag h ON h.id = ph.hashtag_id " +
-            "WHERE b.title = :search " +
-            "GROUP BY p.id " +
-            "ORDER BY like_count DESC " +
-            "LIMIT :limit OFFSET :offset", nativeQuery = true)
-    List<SearchResponse.PostSearchResult> findPostsByBookTitle(
-            @Param("search") String search,
-            @Param("limit") int limit,
-            @Param("offset") int offset);
-
-
-    @Query(value = "SELECT " +
-            "b.title, b.author, b.cover, b.publisher, b.publishing_year, " +
-            "p.id, m.nickname, p.content, p.category, " +
-            "GROUP_CONCAT(DISTINCT h.name) AS hashtags," +
-            "CAST(p.create_at AS CHAR) AS create_at, " +
-            "COUNT(l.id) AS like_count, " +
-            "COUNT(bm.id) AS bookmark_count " +
-            "FROM post p " +
-            "INNER JOIN member m ON m.id = p.writer_id " +
-            "INNER JOIN book b ON b.isbn = p.book_isbn " +
-            "INNER JOIN post_hashtag ph ON ph.post_id = p.id " +
-            "LEFT JOIN likes l ON l.post_id = p.id " +
-            "LEFT JOIN bookmark bm ON bm.post_id = p.id " +
-            "LEFT JOIN hashtag h ON h.id = ph.hashtag_id " +
-            "WHERE ph.post_id IN (" +
-            "  SELECT ph.post_id " +
-            "  FROM post_hashtag ph " +
-            "  INNER JOIN hashtag h ON h.id = ph.hashtag_id " +
-            "  WHERE h.name LIKE :search" +
-            ") " +
-            "GROUP BY p.id " +
-            "ORDER BY like_count DESC " +
-            "LIMIT :limit OFFSET :offset", nativeQuery = true)
-    List<SearchResponse.PostSearchResult> findPostsHashtag(@Param("search") String search,
-                                                           @Param("limit") int limit,
-                                                           @Param("offset") int offset);
-
-    @Query(value = "SELECT " +
-            "b.title , b.author , b.cover, b.publisher, b.publishing_year, " +
-            "p.id , m.nickname, p.content, p.category , " +
-            "GROUP_CONCAT(DISTINCT h.name), " +
-            "CAST(p.create_at AS CHAR) AS create_at, " +
-            "COUNT(l.id) as like_count, " +
-            "COUNT(bm.id) AS bookmark_count " +
-            "FROM post p " +
-            "INNER JOIN member m ON m.id = p.writer_id " +
-            "INNER JOIN book b ON b.isbn = p.book_isbn " +
-            "INNER JOIN post_hashtag ph ON ph.post_id = p.id " +
-            "LEFT JOIN likes l ON l.post_id = p.id " +
-            "LEFT JOIN bookmark bm ON bm.post_id = p.id " +
-            "LEFT JOIN hashtag h ON h.id = ph.hashtag_id " +
-            "WHERE p.category = :search " +
-            "GROUP BY p.id " +
-            "ORDER BY like_count DESC " +
-            "LIMIT :limit OFFSET :offset", nativeQuery = true)
-    List<SearchResponse.PostSearchResult> findPostsCategory(@Param("search") String search,
-                                                           @Param("limit") int limit,
-                                                           @Param("offset") int offset);
 
     @Modifying
     @Query("DELETE FROM Post p WHERE p.deletedAt < :thirtyDays")
@@ -145,16 +71,45 @@ public interface PostRepository extends JpaRepository<Post, Long> {
                 "FROM Bookmark b " +
                 "WHERE b.member.id = :memberId ) " +
             "GROUP BY p.category")
-
     List<PostResponse.CategoryCount> findByMemberBookmarksStatistics(@Param("memberId") Long id);
 
     @Query(value = """
       SELECT p.*
-      FROM Post p
+      FROM post p
       WHERE p.category = :category
       AND p.id NOT IN :duplicatedIds
       ORDER BY RAND()
       LIMIT :count
       """, nativeQuery = true)
     List<Post> findRandomPostsByCategoryAndNotInIds(String category, Set<Long> duplicatedIds, int count);
-           }
+
+
+    @Query("SELECT new today.todaysentence.domain.post.dto.PostResponse$CategoryCount(" +
+          "p.category,SUM(" +
+          "                 CASE " +
+          "                     WHEN p.writer.id = :memberId " +
+          "                         THEN 1 " +
+          "                         ELSE 0 " +
+          "                 END +" +
+          "                 CASE " +
+          "                     WHEN p.id IN(SELECT b.postId FROM Bookmark b WHERE b.member.id = :memberId)" +
+          "                          THEN 1 " +
+          "                          ELSE 0 " +
+          "                 END)" +
+          ")" +
+          "FROM Post p " +
+          "GROUP BY p.category")
+    List<PostResponse.CategoryCount> findByMemberAllStatistics(@Param("memberId") Long memberId);
+
+
+}
+
+
+
+
+
+
+
+
+
+

--- a/src/main/java/today/todaysentence/domain/post/repository/PostRepositoryCustom.java
+++ b/src/main/java/today/todaysentence/domain/post/repository/PostRepositoryCustom.java
@@ -1,0 +1,98 @@
+package today.todaysentence.domain.post.repository;
+
+import jakarta.persistence.EntityManager;
+import jakarta.persistence.Query;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Repository;
+import today.todaysentence.domain.post.dto.PostResponseDTO;
+import today.todaysentence.domain.search.dto.SearchResponse;
+
+import java.util.List;
+
+@RequiredArgsConstructor
+@Repository
+public class PostRepositoryCustom {
+
+    private final EntityManager entityManager;
+
+    public List<SearchResponse.PostSearchResult> findPostsByDynamicQuery(String query) {
+        String sql = "SELECT " +
+                "b.title, b.author, b.cover, b.publisher, b.publishing_year, " +
+                "p.id, m.nickname, p.content, p.category, " +
+                "GROUP_CONCAT(DISTINCT h.name), " +
+                "CAST(p.create_at AS CHAR) AS create_at, " +
+                "COUNT(l.id) as like_count, " +
+                "COUNT(bm.id) as bookmark_count, " +
+                "COUNT(cm.id) as comment_count " +
+                "FROM post p " +
+                "INNER JOIN member m ON m.id = p.writer_id " +
+                "INNER JOIN book b ON b.isbn = p.book_isbn " +
+                "INNER JOIN post_hashtag ph ON ph.post_id = p.id " +
+                "LEFT JOIN likes l ON l.post_id = p.id " +
+                "LEFT JOIN bookmark bm ON bm.post_id = p.id " +
+                "LEFT JOIN hashtag h ON h.id = ph.hashtag_id " +
+                "LEFT JOIN comment cm ON cm.post_id = p.id " +
+                "WHERE " + query + " " +
+                "GROUP BY p.id " +
+                "ORDER BY like_count DESC";
+
+        Query nativeQuery = entityManager.createNativeQuery(sql, SearchResponse.PostSearchResult.class);
+
+        return nativeQuery.getResultList();
+    }
+
+    public PostResponseDTO findPostByDynamicQuery(String query) {
+        String sql = "SELECT " +
+                "b.title, b.author, b.cover, b.publisher, b.publishing_year, " +
+                "p.id, m.nickname, p.content, p.category, " +
+                "GROUP_CONCAT(DISTINCT h.name), " +
+                "CAST(p.create_at AS CHAR) AS create_at, " +
+                "COUNT(l.id) as like_count, " +
+                "COUNT(bm.id) as bookmark_count, " +
+                "COUNT(cm.id) as comment_count " +
+                "FROM post p " +
+                "INNER JOIN member m ON m.id = p.writer_id " +
+                "INNER JOIN book b ON b.isbn = p.book_isbn " +
+                "INNER JOIN post_hashtag ph ON ph.post_id = p.id " +
+                "LEFT JOIN likes l ON l.post_id = p.id " +
+                "LEFT JOIN bookmark bm ON bm.post_id = p.id " +
+                "LEFT JOIN hashtag h ON h.id = ph.hashtag_id " +
+                "LEFT JOIN comment cm ON cm.post_id = p.id " +
+                "WHERE " + query + " " +
+                "GROUP BY p.id " +
+                "ORDER BY like_count DESC";
+
+        Query nativeQuery = entityManager.createNativeQuery(sql, PostResponseDTO.class);
+
+        return (PostResponseDTO)nativeQuery.getSingleResult();
+    }
+
+    public PostResponseDTO findPostByNotMatchMember(String query) {
+        String sql = "SELECT " +
+                "b.title, b.author, b.cover, b.publisher, b.publishing_year, " +
+                "p.id, m.nickname, p.content, p.category, " +
+                "GROUP_CONCAT(DISTINCT h.name), " +
+                "CAST(p.create_at AS CHAR) AS create_at, " +
+                "COUNT(l.id) as like_count, " +
+                "COUNT(bm.id) as bookmark_count, " +
+                "COUNT(cm.id) as comment_count " +
+                "FROM post p " +
+                "INNER JOIN member m ON m.id = p.writer_id " +
+                "INNER JOIN book b ON b.isbn = p.book_isbn " +
+                "INNER JOIN post_hashtag ph ON ph.post_id = p.id " +
+                "LEFT JOIN likes l ON l.post_id = p.id " +
+                "LEFT JOIN bookmark bm ON bm.post_id = p.id " +
+                "LEFT JOIN hashtag h ON h.id = ph.hashtag_id " +
+                "LEFT JOIN comment cm ON cm.post_id = p.id " +
+                "WHERE " + query + " " +
+                "GROUP BY p.id " +
+                "ORDER BY like_count DESC " +
+                "limit 1";
+
+        Query nativeQuery = entityManager.createNativeQuery(sql, PostResponseDTO.class);
+
+        return (PostResponseDTO) nativeQuery.getSingleResult();
+    }
+
+
+}

--- a/src/main/java/today/todaysentence/domain/search/api/SearchController.java
+++ b/src/main/java/today/todaysentence/domain/search/api/SearchController.java
@@ -29,9 +29,9 @@ public class SearchController implements SearchApiSpec {
     }
 
     @GetMapping("/posts")
-    public CommonResponse<?> findPosts(@RequestParam("type")String type, @RequestParam("search")String search, Pageable pageable){
+    public CommonResponse<?> findPosts(@RequestParam("type")String type, @RequestParam("search")String search){
 
-        return searchService.findPosts(type,search,pageable);
+        return searchService.findPosts(type,search);
 
     }
 

--- a/src/main/java/today/todaysentence/domain/search/dto/SearchResponse.java
+++ b/src/main/java/today/todaysentence/domain/search/dto/SearchResponse.java
@@ -35,7 +35,8 @@ public class SearchResponse {
 
             //like_count
             Long likesCount,
-            Long bookmarkCount
+            Long bookmarkCount,
+            Long commentCount
     ) {}
 
 

--- a/src/main/java/today/todaysentence/global/redis/RedisConfig.java
+++ b/src/main/java/today/todaysentence/global/redis/RedisConfig.java
@@ -1,14 +1,16 @@
 package today.todaysentence.global.redis;
 
+import com.fasterxml.jackson.annotation.JsonInclude;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.databind.SerializationFeature;
+import com.fasterxml.jackson.datatype.jsr310.JavaTimeModule;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.data.redis.connection.RedisConnectionFactory;
 import org.springframework.data.redis.connection.lettuce.LettuceConnectionFactory;
 import org.springframework.data.redis.core.RedisTemplate;
-import org.springframework.data.redis.core.StringRedisTemplate;
 import org.springframework.data.redis.serializer.GenericJackson2JsonRedisSerializer;
-import org.springframework.data.redis.serializer.GenericToStringSerializer;
 import org.springframework.data.redis.serializer.StringRedisSerializer;
 
 @Configuration
@@ -31,12 +33,19 @@ public class RedisConfig {
         redisTemplate.setConnectionFactory(connectionFactory);
 
         redisTemplate.setKeySerializer(new StringRedisSerializer());
-        redisTemplate.setValueSerializer(new StringRedisSerializer());
+
+        ObjectMapper objectMapper = new ObjectMapper();
+        objectMapper.registerModule(new JavaTimeModule());
+        objectMapper.disable(SerializationFeature.WRITE_DATES_AS_TIMESTAMPS);
+        objectMapper.setSerializationInclusion(JsonInclude.Include.NON_NULL);
+        objectMapper.configure(SerializationFeature.WRITE_DATES_AS_TIMESTAMPS, false);
+        objectMapper.activateDefaultTyping(objectMapper.getPolymorphicTypeValidator(), ObjectMapper.DefaultTyping.NON_FINAL);
+
+
+        GenericJackson2JsonRedisSerializer serializer = new GenericJackson2JsonRedisSerializer(objectMapper);
+        redisTemplate.setValueSerializer(serializer);
+
 
         return redisTemplate;
     }
-
-
 }
-
-

--- a/src/main/java/today/todaysentence/global/redis/RedisService.java
+++ b/src/main/java/today/todaysentence/global/redis/RedisService.java
@@ -4,6 +4,7 @@ import com.fasterxml.jackson.databind.ObjectMapper;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.data.redis.core.RedisTemplate;
+import org.springframework.data.redis.core.StringRedisTemplate;
 import org.springframework.stereotype.Service;
 import today.todaysentence.domain.post.dto.ScheduledPosts;
 import today.todaysentence.global.jwt.MemberDeviceIdDto;
@@ -22,7 +23,7 @@ public class RedisService {
     private final String DUPLICATED_POST_IDS_KEY = "duplicatePostIds";
 
     private final RedisTemplate<String, Object> redisTemplate;
-
+    private final StringRedisTemplate sRedisTemplate;
     public void saveRefreshToken(String memberId, String refreshToken,String deviceId, long duration) {
         String key = "refresh:" + memberId;
 
@@ -110,8 +111,8 @@ public class RedisService {
             throw new RuntimeException("키를 찾을 수 없습니다. : " + DUPLICATED_POST_IDS_KEY);
         }
 
-        return redisTemplate.opsForSet().members(DUPLICATED_POST_IDS_KEY).stream()
-                .map(id -> (Long)id)
+        return sRedisTemplate.opsForSet().members(DUPLICATED_POST_IDS_KEY).stream()
+                .map(Long::parseLong)
                 .collect(Collectors.toSet());
     }
 
@@ -124,6 +125,6 @@ public class RedisService {
         Set<Long> addedPostIds = scheduledPostsList.stream()
                 .flatMap(scheduledPosts -> scheduledPosts.postIds().stream())
                 .collect(Collectors.toSet());
-        redisTemplate.opsForSet().members(DUPLICATED_POST_IDS_KEY).addAll(addedPostIds);
+        redisTemplate.opsForSet().members("DUPLICATED_POST_IDS_KEY").addAll(addedPostIds);
     }
 }

--- a/src/main/java/today/todaysentence/global/swagger/PostApiSpec.java
+++ b/src/main/java/today/todaysentence/global/swagger/PostApiSpec.java
@@ -11,6 +11,7 @@ import org.springframework.http.ResponseEntity;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import today.todaysentence.domain.post.dto.PostRequest;
 import today.todaysentence.domain.post.dto.PostResponse;
+import today.todaysentence.domain.post.dto.PostResponseDTO;
 import today.todaysentence.global.response.CommonResponse;
 import today.todaysentence.global.security.userDetails.CustomUserDetails;
 
@@ -169,4 +170,31 @@ public interface PostApiSpec {
             }))
     })
     CommonResponse<PostResponse.Statistics> getStatistics( CustomUserDetails userDetails);
+
+    @Operation(summary = "오늘의 명언 조회")
+    @ApiResponses({
+            @ApiResponse(responseCode = "200", content = @Content(mediaType = "application/json", examples = {
+                    @ExampleObject(name = "명언 조회 성공", value = """
+                            {
+                                  "data": {
+                                      "bookTitle": "김종원",
+                                      "bookAuthor": "테스트",
+                                      "bookCover": "image.url",
+                                      "bookPublisher": "출판사1",
+                                      "bookPublishingYear": 2025,
+                                      "postId": 279,
+                                      "postWriter": "test10",
+                                      "postContent": "오늘의명언 테스트 데이터 입니다279",
+                                      "category": "TRAVEL_CULTURE",
+                                      "hashtags": "여행",
+                                      "createAt": "2025-02-16 03:48:31.202127",
+                                      "likesCount": 1,
+                                      "bookmarkCount": 0,
+                                      "commentCount": 0
+                                  }
+                              }
+                            """)
+            }))
+    })
+    CommonResponse<PostResponseDTO> getTodaySentence(@AuthenticationPrincipal CustomUserDetails userDetails);
 }

--- a/src/main/java/today/todaysentence/global/swagger/SearchApiSpec.java
+++ b/src/main/java/today/todaysentence/global/swagger/SearchApiSpec.java
@@ -112,7 +112,7 @@ public interface SearchApiSpec {
                             """)
             })),
     })
-    CommonResponse<?>findPosts(String type, String search, Pageable pageable);
+    CommonResponse<?>findPosts(String type, String search);
 
 
 }

--- a/src/main/java/today/todaysentence/util/scheduler/RecommendationScheduler.java
+++ b/src/main/java/today/todaysentence/util/scheduler/RecommendationScheduler.java
@@ -2,17 +2,19 @@ package today.todaysentence.util.scheduler;
 
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
+import org.springframework.data.redis.core.StringRedisTemplate;
 import org.springframework.scheduling.annotation.Scheduled;
 import org.springframework.stereotype.Component;
 import org.springframework.transaction.annotation.Transactional;
 import today.todaysentence.domain.bookmark.repository.BookmarkRepository;
+import today.todaysentence.domain.hashtag.Hashtag;
+import today.todaysentence.domain.hashtag.repository.HashtagRepository;
 import today.todaysentence.domain.like.repository.LikeRepository;
 import today.todaysentence.domain.member.repository.MemberRepository;
 import today.todaysentence.domain.post.repository.PostRepository;
 
 import java.time.LocalDateTime;
-import java.util.List;
-import java.util.Set;
+import java.util.*;
 
 @Slf4j
 @RequiredArgsConstructor
@@ -23,6 +25,47 @@ public class RecommendationScheduler {
     private final PostRepository postRepository;
     private final LikeRepository likeRepository;
     private final BookmarkRepository bookmarkRepository;
+    private final StringRedisTemplate redisTemplate;
+    private final HashtagRepository hashtagRepository;
+
+
+    @Scheduled(cron = "0 */10 * * * ?")
+
+    public void checkNewHashtag(){
+
+        log.info("start Hashtags insert process");
+
+        List<Long> hashIdsLong = Objects.requireNonNull(redisTemplate.opsForSet().members("hashtagsId"))
+                .stream().map(Long::parseLong)
+                .toList();
+        List<Hashtag> newHashtags;
+
+        if(!hashIdsLong.isEmpty()){
+            newHashtags = hashtagRepository.findNewIds(hashIdsLong);
+        }else{
+            newHashtags = hashtagRepository.findAllIds();
+        }
+
+        if (newHashtags.isEmpty()) return;
+
+        Map<String, Integer> zSetData = new HashMap<>();
+        Set<String> setData = new HashSet<>();
+
+        newHashtags.forEach(tag -> {
+            zSetData.put(tag.getName(), 0);
+            setData.add(String.valueOf(tag.getId()));
+        });
+
+        zSetData.forEach((name, score) ->
+                redisTemplate.opsForZSet().add("hashtags", name, score)
+        );
+        redisTemplate.opsForSet().add("hashtagsId", setData.toArray(new String[0]));
+
+        log.info("new Hashtags count : {}",newHashtags.size());
+
+    }
+
+
 
     @Scheduled(cron = "0 0 1 * * ?")
     @Transactional
@@ -70,4 +113,8 @@ public class RecommendationScheduler {
 
         log.info("Hard delete process completed. Today deleted Members : {} , Posts : {}", memberIdsToDelete.size(), postIdsToDelete.size());
     }
+
+
+
+
 }


### PR DESCRIPTION
기능으로는 
오늘의명언(홈화면)api 추가, 
자동완성 검색을위한 해시테크 캐싱스케쥴 을 추가했습니다.

변경내용으로는 캐싱을위해서 레디스템플릿에 추가설정을해주었고 어제올려주신거

스프링템플릿으로변경했습니다(Interger> string)

포스트의 캐싱을하다가 record타입이 잘 안들어가서...그냥 일반 클래스의 dto로했습니다...

그리고 수경님과 대화중에 명언들을 조회시에 클라이언트사이드로 정렬을하기로 정해서

포스트검색시 페이저블을 제거했습니다.

동적쿼리를 위해서 jpa가아닌 Native SQL를사용으로 바꿨습니다.