### PR TITLE
Refactor: split 'member' field into 'changeTime' field

### DIFF
--- a/src/main/java/today/todaysentence/domain/member/Member.java
+++ b/src/main/java/today/todaysentence/domain/member/Member.java
@@ -34,22 +34,6 @@ public class Member extends Timestamped {
 
     private Long todayPostId;
 
-    @Column(name = "nickname_updated_at")
-    @Builder.Default
-    private LocalDateTime nicknameUpdatedAt = LocalDateTime.now();
-
-    @Column(name = "email_updated_at")
-    @Builder.Default
-    private LocalDateTime emailUpdatedAt = LocalDateTime.now();
-
-    @Column(name = "password_updated_at")
-    @Builder.Default
-    private LocalDateTime passwordUpdatedAt = LocalDateTime.now();
-
-    @Column(name = "message_updated_at")
-    @Builder.Default
-    private LocalDateTime messageUpdatedAt = LocalDateTime.now();
-
     @Setter
     @Builder.Default
     private String profileImg = "basicProfileUrl";

--- a/src/main/java/today/todaysentence/domain/member/MemberUpdateAt.java
+++ b/src/main/java/today/todaysentence/domain/member/MemberUpdateAt.java
@@ -1,0 +1,51 @@
+package today.todaysentence.domain.member;
+
+
+import jakarta.persistence.*;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+import java.time.LocalDateTime;
+
+@Entity
+@NoArgsConstructor
+@AllArgsConstructor
+@Getter
+public class MemberUpdateAt {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    Long id;
+
+    @OneToOne
+    @JoinColumn(name = "member_id")
+    @MapsId
+    private Member member;
+
+    @Column(name = "nickname_updated_at")
+    private LocalDateTime nicknameUpdatedAt;
+
+    @Column(name = "email_updated_at")
+    private LocalDateTime emailUpdatedAt;
+
+    @Column(name = "message_updated_at")
+    private LocalDateTime messageUpdatedAt;
+
+    private LocalDateTime deletedAt;
+
+
+    public MemberUpdateAt(Member member){
+        this.member = member;
+        this.nicknameUpdatedAt = LocalDateTime.now().minusDays(1);
+        this.emailUpdatedAt = LocalDateTime.now().minusDays(1);
+        this.messageUpdatedAt = LocalDateTime.now().minusDays(1);
+    }
+    public void updateMessageTime(){this.messageUpdatedAt = LocalDateTime.now();}
+    public void updateNicknameTime(){this.nicknameUpdatedAt = LocalDateTime.now();}
+    public void updateEmailTime(){this.emailUpdatedAt = LocalDateTime.now();}
+
+
+
+}

--- a/src/main/java/today/todaysentence/domain/member/repository/MemberUpdateAtRepository.java
+++ b/src/main/java/today/todaysentence/domain/member/repository/MemberUpdateAtRepository.java
@@ -1,0 +1,12 @@
+package today.todaysentence.domain.member.repository;
+
+import org.springframework.data.jpa.repository.JpaRepository;
+import today.todaysentence.domain.member.Member;
+import today.todaysentence.domain.member.MemberUpdateAt;
+
+import java.util.Optional;
+
+public interface MemberUpdateAtRepository extends JpaRepository<MemberUpdateAt, Long> {
+
+    Optional<MemberUpdateAt> findByMember(Member member);
+}


### PR DESCRIPTION
기존 닉네임, 이메일, 상태메시지 를 변경시에 기록하던 시간필드들을

멤버조회시에 불필요한 필드들까지 조회되는것을 개선하기위해서

나눠서 관리를 하게했습니다.

MapsId 어노테이션을사용해서 PK를 사용하는 멤버와 같게 설정했습니다.