### PR TITLE
Refactor redis cache

### DIFF
--- a/src/main/java/today/todaysentence/domain/bookmark/service/BookmarkService.java
+++ b/src/main/java/today/todaysentence/domain/bookmark/service/BookmarkService.java
@@ -1,12 +1,14 @@
 package today.todaysentence.domain.bookmark.service;
 
 import lombok.RequiredArgsConstructor;
+import org.springframework.context.ApplicationEventPublisher;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 import today.todaysentence.domain.bookmark.Bookmark;
 import today.todaysentence.domain.bookmark.dto.BookmarkResponse;
 import today.todaysentence.domain.bookmark.repository.BookmarkRepository;
 import today.todaysentence.domain.member.Member;
+import today.todaysentence.domain.post.EventType;
 import today.todaysentence.domain.post.dto.PostResponse;
 import today.todaysentence.domain.post.service.PostService;
 
@@ -15,8 +17,10 @@ import java.util.List;
 @RequiredArgsConstructor
 @Service
 public class BookmarkService {
+
     private final PostService postService;
     private final BookmarkRepository bookmarkRepository;
+    private final ApplicationEventPublisher eventPublisher;
 
     @Transactional
     public BookmarkResponse.SavedStatus bookmark(Long postId, Member member) {
@@ -26,6 +30,8 @@ public class BookmarkService {
                 .orElseGet(() -> bookmarkRepository.save(new Bookmark(member, postId)));
 
         bookmark.toggle();
+
+        eventPublisher.publishEvent(new PostResponse.PostEventDto(postId, EventType.BOOK_MARK,bookmark.getIsSaved()));
 
         if (bookmark.getIsSaved()) {
             return BookmarkResponse.SavedStatus.saved(bookmark.getBookmarkedYear(), bookmark.getBookmarkedMonth());

--- a/src/main/java/today/todaysentence/domain/comment/service/CommentService.java
+++ b/src/main/java/today/todaysentence/domain/comment/service/CommentService.java
@@ -1,6 +1,7 @@
 package today.todaysentence.domain.comment.service;
 
 import lombok.RequiredArgsConstructor;
+import org.springframework.context.ApplicationEventPublisher;
 import org.springframework.data.domain.Pageable;
 import org.springframework.data.domain.Slice;
 import org.springframework.stereotype.Service;
@@ -10,6 +11,8 @@ import today.todaysentence.domain.comment.dto.CommentRequest;
 import today.todaysentence.domain.comment.dto.CommentResponse;
 import today.todaysentence.domain.comment.repository.CommentRepository;
 import today.todaysentence.domain.member.Member;
+import today.todaysentence.domain.post.EventType;
+import today.todaysentence.domain.post.dto.PostResponse;
 import today.todaysentence.domain.post.service.PostService;
 
 @RequiredArgsConstructor
@@ -17,12 +20,14 @@ import today.todaysentence.domain.post.service.PostService;
 public class CommentService {
     private final PostService postService;
     private final CommentRepository commentRepository;
+    private final ApplicationEventPublisher eventPublisher;
 
     @Transactional
     public void create(Member member, Long postId, CommentRequest.Create request) {
         postService.isValidPost(postId);
 
         commentRepository.save(new Comment(member, postId, request.content()));
+        eventPublisher.publishEvent(new PostResponse.PostEventDto(postId, EventType.COMMENT,true));
     }
 
     public CommentResponse.CommentInfos getComments(Long postId, Pageable pageable) {

--- a/src/main/java/today/todaysentence/domain/hashtag/service/HashtagService.java
+++ b/src/main/java/today/todaysentence/domain/hashtag/service/HashtagService.java
@@ -23,6 +23,11 @@ public class HashtagService {
 
     private Hashtag findOrCreateSingle(String hashtagName) {
         return hashtagRepository.findByName(hashtagName)
-                .orElseGet(() -> hashtagRepository.save(new Hashtag(hashtagName)));
+                .orElseGet(() -> {
+                    Hashtag newHashtag = hashtagRepository.save(new Hashtag(hashtagName));
+                    redisService.recordNewHashtag(newHashtag);
+                    return newHashtag;
+                    }
+                );
     }
 }

--- a/src/main/java/today/todaysentence/domain/like/service/LikeService.java
+++ b/src/main/java/today/todaysentence/domain/like/service/LikeService.java
@@ -8,7 +8,10 @@ import today.todaysentence.domain.like.Likes;
 import today.todaysentence.domain.like.dto.LikeResponse;
 import today.todaysentence.domain.like.repository.LikeRepository;
 import today.todaysentence.domain.member.Member;
+import today.todaysentence.domain.post.EventType;
+import today.todaysentence.domain.post.dto.PostResponse;
 import today.todaysentence.domain.post.dto.PostResponseDTO;
+import today.todaysentence.domain.post.repository.PostRepository;
 import today.todaysentence.global.redis.RedisService;
 import today.todaysentence.global.response.CommonResponse;
 
@@ -31,18 +34,9 @@ public class LikeService {
 
         like.toggle();
 
-        PostResponseDTO postCache = redisService.getPostCache(postId);
-        if(postCache != null){
-            if(like.getIsLiked()){
-                postCache.setLikesCount(postCache.getLikesCount()+1);
-            }else{
-                postCache.setLikesCount(postCache.getLikesCount()-1);
-            }
-            redisService.setPostCache(postId,postCache);
-//            stringRedisTemplate.convertAndSend("like_count",String.valueOf(postId));
-            likeRepository.save(like);
-        }
-        eventPublisher.publishEvent(new LikeResponse.LikeEvent(postId));
+        likeRepository.save(like);
+
+        eventPublisher.publishEvent(new PostResponse.PostEventDto(postId, EventType.LIKE,like.getIsLiked()));
 
         return CommonResponse.ok(like.getIsLiked());
     }

--- a/src/main/java/today/todaysentence/domain/member/service/MemberService.java
+++ b/src/main/java/today/todaysentence/domain/member/service/MemberService.java
@@ -3,8 +3,6 @@ package today.todaysentence.domain.member.service;
 import jakarta.mail.MessagingException;
 import jakarta.servlet.http.HttpServletRequest;
 import jakarta.servlet.http.HttpServletResponse;
-import jakarta.validation.constraints.Email;
-import jakarta.validation.constraints.NotBlank;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
@@ -16,7 +14,7 @@ import org.springframework.security.crypto.password.PasswordEncoder;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 import today.todaysentence.domain.bookmark.repository.BookmarkRepository;
-import today.todaysentence.domain.category.Category;
+import today.todaysentence.domain.post.Category;
 import today.todaysentence.domain.comment.repository.CommentRepository;
 import today.todaysentence.domain.like.repository.LikeRepository;
 import today.todaysentence.domain.member.Member;
@@ -46,7 +44,6 @@ import java.time.temporal.ChronoUnit;
 import java.util.Collections;
 import java.util.List;
 import java.util.Map;
-import java.util.Optional;
 import java.util.stream.Collectors;
 
 @RequiredArgsConstructor

--- a/src/main/java/today/todaysentence/domain/post/Category.java
+++ b/src/main/java/today/todaysentence/domain/post/Category.java
@@ -1,4 +1,4 @@
-package today.todaysentence.domain.category;
+package today.todaysentence.domain.post;
 
 import com.fasterxml.jackson.annotation.JsonCreator;
 

--- a/src/main/java/today/todaysentence/domain/post/EventType.java
+++ b/src/main/java/today/todaysentence/domain/post/EventType.java
@@ -1,0 +1,7 @@
+package today.todaysentence.domain.post;
+
+public enum EventType {
+    LIKE,
+    BOOK_MARK,
+    COMMENT
+}

--- a/src/main/java/today/todaysentence/domain/post/Post.java
+++ b/src/main/java/today/todaysentence/domain/post/Post.java
@@ -6,7 +6,6 @@ import lombok.Getter;
 import lombok.NoArgsConstructor;
 import today.todaysentence.domain.member.Member;
 import today.todaysentence.domain.book.Book;
-import today.todaysentence.domain.category.Category;
 import today.todaysentence.domain.hashtag.Hashtag;
 import today.todaysentence.global.timeStamped.Timestamped;
 
@@ -47,6 +46,10 @@ public class Post extends Timestamped {
 
     private String content;
 
+    private Long likeCount = 0L;
+    private Long bookmarkCount = 0L;
+    private Long CommentCount = 0L;
+
     public Post(Member writer, Book book, Category category, List<Hashtag> hashtags, String content) {
         this.writer = writer;
         this.book = book;
@@ -64,4 +67,11 @@ public class Post extends Timestamped {
     public void deleted(){
         this.deletedAt= LocalDateTime.now();
     }
+
+    public void incrementLikeCount(){this.likeCount++;}
+    public void incrementCommentCount(){this.CommentCount++;}
+    public void incrementBookmarkCount(){this.bookmarkCount++;}
+
+    public void decrementLikeCount(){this.likeCount--;}
+    public void decrementBookmarkCount(){this.bookmarkCount--;}
 }

--- a/src/main/java/today/todaysentence/domain/post/dto/PostRequest.java
+++ b/src/main/java/today/todaysentence/domain/post/dto/PostRequest.java
@@ -2,7 +2,7 @@ package today.todaysentence.domain.post.dto;
 
 import jakarta.validation.constraints.NotBlank;
 import jakarta.validation.constraints.NotNull;
-import today.todaysentence.domain.category.Category;
+import today.todaysentence.domain.post.Category;
 
 import java.util.List;
 

--- a/src/main/java/today/todaysentence/domain/post/dto/PostResponse.java
+++ b/src/main/java/today/todaysentence/domain/post/dto/PostResponse.java
@@ -1,9 +1,9 @@
 package today.todaysentence.domain.post.dto;
 
 import lombok.Builder;
-import lombok.Getter;
-import today.todaysentence.domain.category.Category;
+import today.todaysentence.domain.post.Category;
 import today.todaysentence.domain.member.dto.InteractionResponseDTO;
+import today.todaysentence.domain.post.EventType;
 
 import java.util.List;
 import java.util.Map;
@@ -62,5 +62,13 @@ public class PostResponse {
             PostResponseDTO posts,
             InteractionResponseDTO interaction
     ) {}
+
+    public record PostEventDto(
+            Long postId,
+            EventType type,
+            Boolean result
+
+    ){
+    }
 
 }

--- a/src/main/java/today/todaysentence/domain/post/dto/ScheduledPosts.java
+++ b/src/main/java/today/todaysentence/domain/post/dto/ScheduledPosts.java
@@ -1,6 +1,6 @@
 package today.todaysentence.domain.post.dto;
 
-import today.todaysentence.domain.category.Category;
+import today.todaysentence.domain.post.Category;
 
 import java.util.List;
 

--- a/src/main/java/today/todaysentence/domain/post/repository/PostRepository.java
+++ b/src/main/java/today/todaysentence/domain/post/repository/PostRepository.java
@@ -1,8 +1,8 @@
 package today.todaysentence.domain.post.repository;
 
-import org.springframework.data.jpa.repository.JpaRepository;
-import org.springframework.data.jpa.repository.Modifying;
-import org.springframework.data.jpa.repository.Query;
+import jakarta.persistence.LockModeType;
+import jakarta.persistence.QueryHint;
+import org.springframework.data.jpa.repository.*;
 import org.springframework.data.repository.query.Param;
 import org.springframework.lang.NonNull;
 import today.todaysentence.domain.member.Member;
@@ -83,6 +83,13 @@ public interface PostRepository extends JpaRepository<Post, Long> {
     @Query("DELETE FROM Post p WHERE p.deletedAt < :thirtyDays")
     int deletePostsBefore(@Param("thirtyDays") LocalDateTime thirtyDays);
 
+    @Lock(LockModeType.PESSIMISTIC_WRITE)
+    @QueryHints(@QueryHint(name = "javax.persistence.lock.timeout", value = "5000"))
+    @Query("SELECT p FROM Post p " +
+            "JOIN FETCH p.writer m " +
+            "JOIN FETCH p.hashtags h " +
+            "WHERE p.id = :postId")
+    Optional<Post> findByIdLock(@Param("postId") Long postId);
 }
 
 

--- a/src/main/java/today/todaysentence/domain/post/repository/PostRepositoryCustom.java
+++ b/src/main/java/today/todaysentence/domain/post/repository/PostRepositoryCustom.java
@@ -7,7 +7,6 @@ import org.springframework.stereotype.Repository;
 import today.todaysentence.domain.member.dto.InteractionResponseDTO;
 import today.todaysentence.domain.post.dto.PostCategoryLikeCountDTO;
 import today.todaysentence.domain.post.dto.PostResponseDTO;
-import today.todaysentence.domain.post.dto.PostResponseTestDTO;
 
 import java.util.List;
 import java.util.stream.Collectors;

--- a/src/main/java/today/todaysentence/domain/post/repository/PostRepositoryCustom.java
+++ b/src/main/java/today/todaysentence/domain/post/repository/PostRepositoryCustom.java
@@ -7,6 +7,7 @@ import org.springframework.stereotype.Repository;
 import today.todaysentence.domain.member.dto.InteractionResponseDTO;
 import today.todaysentence.domain.post.dto.PostCategoryLikeCountDTO;
 import today.todaysentence.domain.post.dto.PostResponseDTO;
+import today.todaysentence.domain.post.dto.PostResponseTestDTO;
 
 import java.util.List;
 import java.util.stream.Collectors;
@@ -24,23 +25,18 @@ public class PostRepositoryCustom {
                 "p.id, m.nickname, p.content, p.category, " +
                 "GROUP_CONCAT(DISTINCT h.name), " +
                 "CAST(p.create_at AS CHAR) AS create_at, " +
-                "COUNT(DISTINCT l.id) as like_count, " +
-                "COUNT(DISTINCT bm.id) as bookmark_count, " +
-                "COUNT(DISTINCT cm.id) as comment_count " +
+                "p.like_count, " +
+                "p.bookmark_count, " +
+                "p.comment_count " +
                 "FROM post p " +
                 "INNER JOIN member m ON m.id = p.writer_id " +
                 "INNER JOIN book b ON b.isbn = p.book_isbn " +
                 "INNER JOIN post_hashtag ph ON ph.post_id = p.id " +
-                "LEFT JOIN likes l ON l.post_id = p.id AND l.deleted_at IS NULL AND l.is_liked = true " +
-                "LEFT JOIN bookmark bm ON bm.post_id = p.id AND bm.deleted_at IS NULL AND bm.is_saved = true " +
                 "LEFT JOIN hashtag h ON h.id = ph.hashtag_id " +
-                "LEFT JOIN comment cm ON cm.post_id = p.id AND cm.deleted_at IS NULL " +
                 "WHERE " + query + " AND p.deleted_at IS NULL " +
                 "GROUP BY p.id " +
                 "ORDER BY " + orderBy +",p.id DESC "+
                 "LIMIT :size OFFSET :offset";
-
-
 
         Query nativeQuery = entityManager.createNativeQuery(sql, PostResponseDTO.class);
 
@@ -57,17 +53,14 @@ public class PostRepositoryCustom {
                 "p.id, m.nickname, p.content, p.category, " +
                 "GROUP_CONCAT(DISTINCT h.name), " +
                 "CAST(p.create_at AS CHAR) AS create_at, " +
-                "COUNT(DISTINCT l.id) as like_count, " +
-                "COUNT(DISTINCT bm.id) as bookmark_count, " +
-                "COUNT(DISTINCT cm.id) as comment_count " +
+                "p.like_count, " +
+                "p.bookmark_count, " +
+                "p.comment_count " +
                 "FROM post p " +
                 "INNER JOIN member m ON m.id = p.writer_id " +
                 "INNER JOIN book b ON b.isbn = p.book_isbn " +
                 "INNER JOIN post_hashtag ph ON ph.post_id = p.id " +
-                "LEFT JOIN likes l ON l.post_id = p.id AND l.deleted_at IS NULL AND l.is_liked = true " +
-                "LEFT JOIN bookmark bm ON bm.post_id = p.id AND bm.deleted_at IS NULL AND bm.is_saved = true " +
                 "LEFT JOIN hashtag h ON h.id = ph.hashtag_id " +
-                "LEFT JOIN comment cm ON cm.post_id = p.id AND cm.deleted_at IS NULL " +
                 "WHERE " + query + " AND p.deleted_at IS NULL " +
                 "GROUP BY p.id " +
                 "ORDER BY like_count DESC, p.id DESC";
@@ -85,17 +78,14 @@ public class PostRepositoryCustom {
                 "p.id, m.nickname, p.content, p.category, " +
                 "GROUP_CONCAT(DISTINCT h.name), " +
                 "CAST(p.create_at AS CHAR) AS create_at, " +
-                "COUNT(DISTINCT l.id) as like_count, " +
-                "COUNT(DISTINCT bm.id) as bookmark_count, " +
-                "COUNT(DISTINCT cm.id) as comment_count " +
+                "p.like_count, " +
+                "p.bookmark_count, " +
+                "p.comment_count " +
                 "FROM post p " +
                 "INNER JOIN member m ON m.id = p.writer_id " +
                 "INNER JOIN book b ON b.isbn = p.book_isbn " +
                 "INNER JOIN post_hashtag ph ON ph.post_id = p.id " +
-                "LEFT JOIN likes l ON l.post_id = p.id AND l.deleted_at IS NULL AND l.is_liked = true " +
-                "LEFT JOIN bookmark bm ON bm.post_id = p.id AND bm.deleted_at IS NULL AND bm.is_saved = true " +
                 "LEFT JOIN hashtag h ON h.id = ph.hashtag_id " +
-                "LEFT JOIN comment cm ON cm.post_id = p.id AND cm.deleted_at IS NULL " +
                 "WHERE " + query + " " +
                 "GROUP BY p.id " +
                 "ORDER BY like_count DESC " +
@@ -163,9 +153,8 @@ public class PostRepositoryCustom {
     public PostCategoryLikeCountDTO findPostCategoryAndLikeCount(Long postId) {
         String query = "SELECT " +
                 "p.category, " +
-                "COUNT(DISTINCT l.id) as like_count " +
+                "p.like_count " +
                 "FROM post p " +
-                "LEFT JOIN likes l ON l.post_id = p.id AND l.is_liked = true AND l.deleted_at IS NULL " +
                 "WHERE p.id = :postId " +
                 "GROUP BY p.id ";
 
@@ -175,5 +164,4 @@ public class PostRepositoryCustom {
         return (PostCategoryLikeCountDTO)nativeQuery.getSingleResult();
     }
 
-//    public
 }

--- a/src/main/java/today/todaysentence/domain/post/service/PostService.java
+++ b/src/main/java/today/todaysentence/domain/post/service/PostService.java
@@ -7,7 +7,7 @@ import org.springframework.transaction.annotation.Transactional;
 import today.todaysentence.domain.book.Book;
 import today.todaysentence.domain.book.dto.BookInfo;
 import today.todaysentence.domain.book.service.BookService;
-import today.todaysentence.domain.category.Category;
+import today.todaysentence.domain.post.Category;
 import today.todaysentence.domain.hashtag.Hashtag;
 import today.todaysentence.domain.hashtag.service.HashtagService;
 import today.todaysentence.domain.member.Member;
@@ -35,6 +35,8 @@ import java.util.concurrent.TimeUnit;
 import java.util.stream.Collectors;
 import java.util.stream.IntStream;
 import java.util.stream.Stream;
+
+import static today.todaysentence.global.redis.RedisService.*;
 
 @RequiredArgsConstructor
 @Service
@@ -183,14 +185,14 @@ public class PostService {
         }
 
         //step4 캐싱값 확인 CacheHit >> 바로반환  CacheMiss >>  DATABASE 조회후 캐싱후 반환
-        return Optional.ofNullable((PostResponseDTO)redisTemplate.opsForValue().get("postId : " + randomPostId))
+        return Optional.ofNullable((PostResponseDTO)redisTemplate.opsForValue().get(POST_CACHE_KEY+ randomPostId))
                 .map(post -> new PostResponse.PostResult(post, memberService.checkInteraction(randomPostId, member.getId())))
                 .or(() -> {
                     String query = "p.id = " + randomPostId;
                     PostResponseDTO result = postRepositoryCustom.findPostByDynamicQuery(query);
                     InteractionResponseDTO interaction = memberService.checkInteraction(randomPostId, member.getId());
 
-                    redisTemplate.opsForValue().set("postId : " + randomPostId, result, 15, TimeUnit.MINUTES);
+                    redisTemplate.opsForValue().set(POST_CACHE_KEY+ randomPostId, result, 15, TimeUnit.MINUTES);
 
                     return Optional.of(new PostResponse.PostResult(result, interaction));
                 })
@@ -217,7 +219,7 @@ public class PostService {
                 .skip(skipRank)
                 .limit(rank)
                 .flatMap(c->{
-                    List<Long> memberIds = (List<Long>) redisTemplate.opsForHash().get(c.name(), "writer_id");
+                    List<Long> memberIds = (List<Long>) redisTemplate.opsForHash().get(c.name(), TODAY_SENTENCE_WRITER_IDS);
 
                     if (memberIds == null) {
                         return Stream.empty();
@@ -229,7 +231,7 @@ public class PostService {
                                     .boxed()
                                     .toList();
 
-                    List<Long> postIdsList = (List<Long>) redisTemplate.opsForHash().get(c.name(), "post_id");
+                    List<Long> postIdsList = (List<Long>) redisTemplate.opsForHash().get(c.name(), TODAY_SENTENCE_POST_IDS);
 
                     if (postIdsList == null) {
                         return Stream.empty();

--- a/src/main/java/today/todaysentence/domain/search/service/SearchService.java
+++ b/src/main/java/today/todaysentence/domain/search/service/SearchService.java
@@ -11,8 +11,6 @@ import today.todaysentence.domain.member.dto.InteractionResponseDTO;
 import today.todaysentence.domain.member.service.MemberService;
 import today.todaysentence.domain.post.dto.PostResponse;
 import today.todaysentence.domain.post.dto.PostResponseDTO;
-import today.todaysentence.domain.post.dto.PostResponseTestDTO;
-import today.todaysentence.domain.post.repository.PostRepository;
 import today.todaysentence.domain.post.repository.PostRepositoryCustom;
 import today.todaysentence.domain.search.dto.SearchResponse;
 import today.todaysentence.global.exception.exception.BaseException;

--- a/src/main/java/today/todaysentence/domain/search/service/SearchService.java
+++ b/src/main/java/today/todaysentence/domain/search/service/SearchService.java
@@ -11,6 +11,8 @@ import today.todaysentence.domain.member.dto.InteractionResponseDTO;
 import today.todaysentence.domain.member.service.MemberService;
 import today.todaysentence.domain.post.dto.PostResponse;
 import today.todaysentence.domain.post.dto.PostResponseDTO;
+import today.todaysentence.domain.post.dto.PostResponseTestDTO;
+import today.todaysentence.domain.post.repository.PostRepository;
 import today.todaysentence.domain.post.repository.PostRepositoryCustom;
 import today.todaysentence.domain.search.dto.SearchResponse;
 import today.todaysentence.global.exception.exception.BaseException;
@@ -23,8 +25,7 @@ import today.todaysentence.global.security.userDetails.JwtUserDetails;
 import java.util.*;
 import java.util.stream.Collectors;
 
-import static today.todaysentence.global.redis.RedisService.FAMOUS_RECORD_TAG_KEY;
-import static today.todaysentence.global.redis.RedisService.FAMOUS_SEARCH_TAG_KEY;
+import static today.todaysentence.global.redis.RedisService.*;
 
 @Service
 @RequiredArgsConstructor
@@ -45,18 +46,16 @@ public class SearchService {
 
         Page<SearchResponse.BookSearchResult> books;
 
-        if ("title".equals(type)) {
-            books = bookRepository.findByTitleContain(search, pageable);
-        } else if ("author".equals(type)) {
-            books = bookRepository.findByAuthorContain(search, pageable);
-        } else {
-            throw new BaseException(ExceptionCode.NOT_MATCHED_TYPE_PARAMETER);
+        switch (type){
+            case "title" ->  books = bookRepository.findByTitleContain(search, pageable);
+            case "author" ->  books = bookRepository.findByAuthorContain(search, pageable);
+            default ->  throw new BaseException(ExceptionCode.NOT_MATCHED_TYPE_PARAMETER);
+
         }
+
         if (books.isEmpty()) {
             return CommonResponse.ok("검색 결과가 없습니다.");
         }
-
-
 
         return CommonResponse.ok(books);
     }
@@ -78,7 +77,7 @@ public class SearchService {
         //캐시먼저검사 (look aside)
         List<PostResponseDTO> posts;
 
-        if(type.equals("category") && page<5){
+        if(!sortField.equals("create_at") && type.equals("category") && page<5){
             String key = type+"_"+search;
 
             //캐시검사
@@ -134,13 +133,9 @@ public class SearchService {
 
         String query;
         switch (type){
-            case "title" -> {
-                query=" b.title = :search ";
-            }
+            case "title" -> query=" b.title = :search ";
 
-            case "category" -> {
-                query=" p.category = :search ";
-            }
+            case "category" -> query=" p.category = :search ";
 
             case "tag" -> {
                 redisService.saveOrUpdateKeyword("search", search);
@@ -159,7 +154,7 @@ public class SearchService {
 
     private static String getOrderByQuery(String sortField) {
 
-        String orderByQuery  = " like_count DESC ";
+        String orderByQuery  = " p.like_count DESC ";
 
         if(sortField.equals("create_at")){
             orderByQuery  = " p.create_at DESC ";
@@ -194,7 +189,7 @@ public class SearchService {
         Range.Bound<String> upperBound = Range.Bound.inclusive(max);
         Range<String> range = Range.of(lowerBound, upperBound);
 
-        Set<String> allTags = stringRedisTemplate.opsForZSet().rangeByLex("hashtags", range);
+        Set<String> allTags = stringRedisTemplate.opsForZSet().rangeByLex(HASHTAGS_LIST, range);
 
         return allTags.stream()
                 .filter(tag -> tag.contains(prefix))
@@ -219,7 +214,5 @@ public class SearchService {
 
         return CommonResponse.ok(new SearchResponse.HashTagRank(search,record)) ;
     }
-
-
 
 }

--- a/src/main/java/today/todaysentence/global/redis/RedisConfig.java
+++ b/src/main/java/today/todaysentence/global/redis/RedisConfig.java
@@ -24,8 +24,6 @@ public class RedisConfig {
     @Value("${spring.data.redis.port}")
     private int redisPort;
 
-//    private final LikeMessageListener likeMessageListener;
-
     @Bean
     public RedisConnectionFactory redisConnectionFactory() {
         return new LettuceConnectionFactory(redisHost, redisPort);
@@ -45,30 +43,10 @@ public class RedisConfig {
         objectMapper.configure(SerializationFeature.WRITE_DATES_AS_TIMESTAMPS, false);
         objectMapper.activateDefaultTyping(objectMapper.getPolymorphicTypeValidator(), ObjectMapper.DefaultTyping.NON_FINAL);
 
-
         GenericJackson2JsonRedisSerializer serializer = new GenericJackson2JsonRedisSerializer(objectMapper);
         redisTemplate.setValueSerializer(serializer);
 
-
         return redisTemplate;
     }
-
-
-
-    // 메시지 리스너 컨테이너 등록 방법1
-//    @Bean
-//    public RedisMessageListenerContainer messageListenerContainer(RedisConnectionFactory connectionFactory) {
-//        RedisMessageListenerContainer container = new RedisMessageListenerContainer();
-//        container.setConnectionFactory(connectionFactory);
-//        container.addMessageListener(new MessageListenerAdapter(likeMessageListener), new ChannelTopic("like_count"));
-//        return container;
-//    }
-    //방법 2 간단하게 사용할 수 있다고하네요
-//    @RedisListener(topics = "likeQueue")
-//    public void processLike(LikeEvent event) {
-//        Likes like = likeRepository.findByPostId(event.getPostId()).orElseGet(() -> createLike(event.getPostId()));
-//        like.toggle();
-//        likeRepository.save(like);
-//    }
 
 }

--- a/src/main/java/today/todaysentence/global/redis/RedisService.java
+++ b/src/main/java/today/todaysentence/global/redis/RedisService.java
@@ -4,15 +4,21 @@ import com.fasterxml.jackson.databind.ObjectMapper;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.context.event.EventListener;
+import org.springframework.dao.DeadlockLoserDataAccessException;
+import org.springframework.data.redis.RedisSystemException;
 import org.springframework.data.redis.core.RedisTemplate;
 import org.springframework.data.redis.core.StringRedisTemplate;
 import org.springframework.scheduling.annotation.Async;
 import org.springframework.stereotype.Service;
-import today.todaysentence.domain.category.Category;
-import today.todaysentence.domain.like.dto.LikeResponse;
-import today.todaysentence.domain.post.dto.PostCategoryLikeCountDTO;
+import org.springframework.transaction.annotation.Transactional;
+import today.todaysentence.domain.post.Category;
+import today.todaysentence.domain.hashtag.Hashtag;
+import today.todaysentence.domain.post.EventType;
+import today.todaysentence.domain.post.Post;
+import today.todaysentence.domain.post.dto.PostResponse;
 import today.todaysentence.domain.post.dto.PostResponseDTO;
 import today.todaysentence.domain.post.dto.ScheduledPosts;
+import today.todaysentence.domain.post.repository.PostRepository;
 import today.todaysentence.domain.post.repository.PostRepositoryCustom;
 import today.todaysentence.global.jwt.MemberDeviceIdDto;
 
@@ -27,14 +33,21 @@ import static today.todaysentence.domain.search.service.SearchService.CACHE_MAX_
 @Slf4j
 public class RedisService {
     private final String DUPLICATED_POST_IDS_KEY = "duplicatePostIds";
-    private final String POST_CACHE_KEY = "postId : ";
+
+    public static final String POST_CACHE_KEY = "postId : ";
     public static final String FAMOUS_SEARCH_TAG_KEY ="search_tag";
     public static final String FAMOUS_RECORD_TAG_KEY ="record_tag";
+    public static final String HASHTAGS_LIST = "hashtags";
+    public static final String TODAY_SENTENCE_POST_IDS = "post_id";
+    public static final String TODAY_SENTENCE_WRITER_IDS = "writer_id";
+
+
 
     private final RedisTemplate<String, Object> redisTemplate;
     private final StringRedisTemplate sRedisTemplate;
 
     private final PostRepositoryCustom postRepositoryCustom;
+    private final PostRepository postRepository;
 
     public void saveRefreshToken(String memberId, String refreshToken,String deviceId, long duration) {
         String key = "refresh:" + memberId;
@@ -88,8 +101,10 @@ public class RedisService {
         redisTemplate.delete(key);
         log.info("리프레쉬 키 삭제 Member : {}", memberEmail);
     }
+
     public void addToBlacklist(String token, long expirationTime) {
-        redisTemplate.opsForValue().set(token, "blacklisted", expirationTime, TimeUnit.MILLISECONDS);
+        String BLACK_LIST = "blacklist";
+        redisTemplate.opsForValue().set(token, BLACK_LIST, expirationTime, TimeUnit.MILLISECONDS);
     }
 
     public boolean isBlacklisted(String token) {
@@ -98,9 +113,7 @@ public class RedisService {
 
 
     public void saveCode(String email, String code,long duration) {
-        String Key = email;
-        String value = code;
-        redisTemplate.opsForValue().set(Key, value, duration, TimeUnit.MILLISECONDS);
+        redisTemplate.opsForValue().set(email, code, duration, TimeUnit.MILLISECONDS);
 
     }
 
@@ -131,8 +144,8 @@ public class RedisService {
 
     public void addScheduledPosts(List<ScheduledPosts> scheduledPostsList) {
         scheduledPostsList.forEach(scheduledPosts -> {
-                redisTemplate.opsForHash().put(scheduledPosts.category().name(), "post_id", scheduledPosts.postIds());
-                redisTemplate.opsForHash().put(scheduledPosts.category().name(), "writer_id", scheduledPosts.writerIds());
+                redisTemplate.opsForHash().put(scheduledPosts.category().name(), TODAY_SENTENCE_POST_IDS, scheduledPosts.postIds());
+                redisTemplate.opsForHash().put(scheduledPosts.category().name(), TODAY_SENTENCE_WRITER_IDS, scheduledPosts.writerIds());
                 });
 
         Set<Long> addedPostIds = scheduledPostsList.stream()
@@ -147,8 +160,8 @@ public class RedisService {
         try{
             log.info("check today-sentence postIds due to member withdraw");
             check.forEach((withdrawMemberId,category)->{
-                List<Long> posts = new ArrayList<>((List<Long>) Objects.requireNonNull(redisTemplate.opsForHash().get(category.name(), "post_id")));
-                List<Long> members = new ArrayList<>((List<Long>) Objects.requireNonNull(redisTemplate.opsForHash().get(category.name(), "writer_id")));
+                List<Long> posts = new ArrayList<>((List<Long>) Objects.requireNonNull(redisTemplate.opsForHash().get(category.name(), TODAY_SENTENCE_POST_IDS)));
+                List<Long> members = new ArrayList<>((List<Long>) Objects.requireNonNull(redisTemplate.opsForHash().get(category.name(), TODAY_SENTENCE_WRITER_IDS)));
 
                 if (posts.contains(withdrawMemberId)) {
                     log.info("today sentence postIds reSettings [ category : {} ]  [ removePostId : {} ]",category.name(),withdrawMemberId);
@@ -156,8 +169,8 @@ public class RedisService {
                     posts.remove(index);
                     members.remove(index);
 
-                    redisTemplate.opsForHash().put(category.name(), "post_id", posts);
-                    redisTemplate.opsForHash().put(category.name(), "writer_id", members);
+                    redisTemplate.opsForHash().put(category.name(), TODAY_SENTENCE_POST_IDS, posts);
+                    redisTemplate.opsForHash().put(category.name(), TODAY_SENTENCE_WRITER_IDS, members);
 
                 }else{
                     log.info("no deleted postIds");
@@ -223,59 +236,85 @@ public class RedisService {
      * 좋아요가 눌리면 해당 post의 카테고리와 likeCount를 찾아와서
      * 해당 post가 이미등록된 캐싱에 포함이 되어있는지 확인을한다
      * true -> 기존데이터를 삭제후에 새롭게 넣는다
-     * false -> 아직 캐싱데이터의.size가 30개가안된다면 바로집어넣고
-     * 넘는다면 기존의것을 넣고 30개를 유지한다.
+     * false -> 아직 캐싱데이터의.size가 50개가안된다면 바로집어넣고
+     * 넘는다면 기존의것을 넣고 50개를 유지한다.
      *
-     * @variable CACHE_MAX_SIZE 캐시 최대 크기. 캐시가 30개 이상이 되면 기존 데이터를 삭제하고 새로 추가.
+     * @variable CACHE_MAX_SIZE 캐시 최대 크기. 캐시가 50개 이상이 되면 기존 데이터를 삭제하고 새로 추가.
      *
      *  */
     @EventListener
     @Async("taskExecutor")
-    public void searchRankObserver(LikeResponse.LikeEvent postId){
+    @Transactional
+    public void searchRankObserver(PostResponse.PostEventDto event) {
+        Long postId = event.postId();
 
-        //이벤트발생으로 전달받은 post의 category와 likecount를 가져온다
-        PostCategoryLikeCountDTO categoryAndCount = postRepositoryCustom.findPostCategoryAndLikeCount(postId.postId());
+        Post post = postRepository.findByIdLock(postId).orElseThrow();
 
-        Long listenPostId = postId.postId();
+        try {
+            if (event.type() == EventType.LIKE) {
+                if (event.result()) {
+                    post.incrementLikeCount();
+                } else {
+                    post.decrementLikeCount();
+                }
+            } else if (event.type() == EventType.BOOK_MARK) {
+                if (event.result()) {
+                    post.incrementBookmarkCount();
+                } else {
+                    post.decrementBookmarkCount();
+                }
+            } else if (event.type() == EventType.COMMENT) {
+                post.incrementCommentCount();
+            }
 
-        //key
-        String key = "category_"+categoryAndCount.getCategory();
+            postRepository.save(post);
 
-        //기존에 등록된 전체를 가져온다.
-        Set<Object> allEntries = redisTemplate.opsForZSet().range(key,0,-1);
-        
-        //기존에 포함된것인지 확인.
+        } catch (DeadlockLoserDataAccessException e) {
+            throw new RuntimeException(e);
+        }
+
+        updateRedisCache(post, event, post.getLikeCount());
+    }
+
+    private void updateRedisCache(Post post, PostResponse.PostEventDto event, Long likeCount) {
+
+        Long listenPostId = post.getId();
+
+        //오늘의명언 부분
+        PostResponseDTO todaySentence = getPostCache(listenPostId);
+
+        if(todaySentence!=null){
+            updateTodaySentence(listenPostId);
+        }
+
+        String key = "category_" + post.getCategory();
+
+        // Redis에서 기존 항목을 가져옴
+        Set<Object> allEntries = redisTemplate.opsForZSet().range(key, 0, -1);
         PostResponseDTO existing = getPostResponseDTO(allEntries, listenPostId);
 
-        //기존에것이 있을시 삭제후 add
-        if(existing != null) {
-            redisTemplate.opsForZSet().remove(key,existing);
-            addNewEntry(listenPostId,key);
+        // 기존에 있으면 삭제 후 새 항목 추가
+        if (existing != null) {
+            redisTemplate.opsForZSet().remove(key, existing);
+            addNewEntry(listenPostId, key);
+        } else if (event.type() == EventType.LIKE) {
+            Set<Object> lastEntries = redisTemplate.opsForZSet().range(key, 0, 0);
+            PostResponseDTO lastEntry = (PostResponseDTO) lastEntries.iterator().next();
 
-        }else if(allEntries.size()<CACHE_MAX_SIZE) { //기존에 없지만 아직 30개가 채워지지않았을경우 
-            addNewEntry(listenPostId,key);
-
-        }else{ //기존에도없고 30개도 넘었을시에 마지막과 비교
-            Set<Object> lastEntries = redisTemplate.opsForZSet().range(key,0,0);
-
-            PostResponseDTO lastEntry =(PostResponseDTO) lastEntries.iterator().next();
-
-            //비교해서 기존의것보다 더 카운팅이 높다면 추가 및 기존삭제
-            if (lastEntry.getLikesCount() < categoryAndCount.getLikeCount()) {
+            // 기존 항목과 비교하여, 더 높은 카운트면 추가 및 기존 항목 삭제
+            if (lastEntry.getLikesCount() < likeCount) {
                 redisTemplate.opsForZSet().remove(key, lastEntry);
                 addNewEntry(listenPostId, key);
             }
         }
-
     }
 
     private PostResponseDTO getPostResponseDTO(Set<Object> allEntries, Long listenPostId) {
-        PostResponseDTO existing = allEntries.stream()
+        return allEntries.stream()
                 .map(o->(PostResponseDTO)o)
                 .filter(post->post.getPostId().equals(listenPostId))
                 .findFirst()
                 .orElse(null);
-        return existing;
     }
 
     private void addNewEntry(Long listenPostId, String key) {
@@ -284,5 +323,15 @@ public class RedisService {
         redisTemplate.opsForZSet().add(key,newEntry,newEntry.getLikesCount());
     }
 
+    private void updateTodaySentence(Long listenPostId) {
+        String query = " p.id = "+ listenPostId;
+        PostResponseDTO newTodaySentence = postRepositoryCustom.findPostByDynamicQuery(query);
+        redisTemplate.opsForValue().set(POST_CACHE_KEY+listenPostId, newTodaySentence, 15, TimeUnit.MINUTES);
+    }
+
+
+    public void recordNewHashtag(Hashtag newHashtag) {
+        redisTemplate.opsForZSet().add(HASHTAGS_LIST,newHashtag.getName(),0);
+    }
 
 }

--- a/src/main/java/today/todaysentence/util/scheduler/RecommendationScheduler.java
+++ b/src/main/java/today/todaysentence/util/scheduler/RecommendationScheduler.java
@@ -32,43 +32,6 @@ public class RecommendationScheduler {
     private final RedisService redisService;
     private final CommentRepository commentRepository;
 
-
-    @Scheduled(cron = "0 */10 * * * ?")
-
-    public void checkNewHashtag(){
-
-        log.info("start Hashtags insert process");
-
-        List<Long> hashIdsLong = Objects.requireNonNull(redisTemplate.opsForSet().members("hashtagsId"))
-                .stream().map(Long::parseLong)
-                .toList();
-        List<Hashtag> newHashtags;
-
-        if(!hashIdsLong.isEmpty()){
-            newHashtags = hashtagRepository.findNewIds(hashIdsLong);
-        }else{
-            newHashtags = hashtagRepository.findAllIds();
-        }
-
-        if (newHashtags.isEmpty()) return;
-
-        Map<String, Integer> zSetData = new HashMap<>();
-        Set<String> setData = new HashSet<>();
-
-        newHashtags.forEach(tag -> {
-            zSetData.put(tag.getName(), 0);
-            setData.add(String.valueOf(tag.getId()));
-        });
-
-        zSetData.forEach((name, score) ->
-                redisTemplate.opsForZSet().add("hashtags", name, score)
-        );
-        redisTemplate.opsForSet().add("hashtagsId", setData.toArray(new String[0]));
-
-        log.info("new Hashtags count : {}",newHashtags.size());
-
-    }
-
     @Scheduled(fixedDelay = 600000)
     public void famousTagsZeroScoreDelAndDecrement() {
         redisService.decreaseAllScoresForAllTags(2);


### PR DESCRIPTION
기존 post 테이블에 likecount, bookmarkCount, commentCount 추가
각 필드 변경시 비관적락 적용

캐싱 로직 변경(테이블 변경에의한 기존방식에서 추가된 Count필드도 캐시에 업데이트)

카테고리 Eunm -> Post 패키지로 이동

 