### PR TITLE
s3 업로드 및 멤버 엔티티 profile 필드 변경 기능 추가

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -71,9 +71,8 @@ dependencies {
     //log-loki
     implementation 'com.github.loki4j:loki-logback-appender:1.4.2'
 
-
-
-
+    // s3
+    implementation 'org.springframework.cloud:spring-cloud-starter-aws:2.2.6.RELEASE'
 }
 
 tasks.named('test') {

--- a/src/main/java/today/todaysentence/domain/member/Member.java
+++ b/src/main/java/today/todaysentence/domain/member/Member.java
@@ -34,7 +34,6 @@ public class Member extends Timestamped {
 
     private Long todayPostId;
 
-    @Setter
     @Builder.Default
     private String profileImg = "basicProfileUrl";
 
@@ -69,5 +68,11 @@ public class Member extends Timestamped {
 
     public void removeTodaySentenceId(){ this.todayPostId = null;}
 
+    public boolean isDefaultProfile() {
+        return "basicProfileUrl".equals(profileImg);
+    }
 
+    public void changeProfile(String profileUrl) {
+        this.profileImg = profileUrl;
+    }
 }

--- a/src/main/java/today/todaysentence/domain/member/api/MemberController.java
+++ b/src/main/java/today/todaysentence/domain/member/api/MemberController.java
@@ -1,6 +1,5 @@
 package today.todaysentence.domain.member.api;
 
-import io.swagger.v3.oas.annotations.tags.Tag;
 import jakarta.mail.MessagingException;
 import jakarta.servlet.http.HttpServletRequest;
 import jakarta.servlet.http.HttpServletResponse;
@@ -9,6 +8,8 @@ import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.web.bind.annotation.*;
+import org.springframework.web.multipart.MultipartFile;
+import today.todaysentence.domain.member.Member;
 import today.todaysentence.domain.member.dto.MemberRequest;
 import today.todaysentence.domain.member.dto.MemberResponse;
 import today.todaysentence.domain.member.service.MemberService;
@@ -26,7 +27,7 @@ public class MemberController implements MemberApiSpec {
 
     @Override
     @GetMapping()
-    public CommonResponse<MemberResponse.MemberInfo>getMemberInfo(@AuthenticationPrincipal CustomUserDetails userDetails){
+    public CommonResponse<MemberResponse.MemberInfo> getMemberInfo(@AuthenticationPrincipal CustomUserDetails userDetails) {
         return memberService.getMemberInfo(userDetails);
     }
 
@@ -38,26 +39,26 @@ public class MemberController implements MemberApiSpec {
 
     @Override
     @PostMapping("/sign-in")
-    public CommonResponse<?> signIn(@RequestBody @Valid  MemberRequest.SignIn signIn, HttpServletRequest request,HttpServletResponse response) {
-        return memberService.signIn(signIn,request,response);
+    public CommonResponse<?> signIn(@RequestBody @Valid MemberRequest.SignIn signIn, HttpServletRequest request, HttpServletResponse response) {
+        return memberService.signIn(signIn, request, response);
     }
 
     @Override
     @DeleteMapping("/sign-out")
     public CommonResponse<?> signOut(@AuthenticationPrincipal CustomUserDetails userDetails, HttpServletRequest request) {
-        return memberService.signOut(userDetails,request);
+        return memberService.signOut(userDetails, request);
     }
 
     @Override
     @GetMapping("/withdraw")
     public CommonResponse<?> withdraw(@AuthenticationPrincipal CustomUserDetails userDetails, HttpServletRequest request) {
-        return memberService.withdraw(userDetails,request);
+        return memberService.withdraw(userDetails, request);
     }
 
     @Override
     @PostMapping("/verify-password")
-    public CommonResponse<?> checkVerificationPassword(@AuthenticationPrincipal CustomUserDetails userDetails,@RequestBody MemberRequest.CheckPassword password) {
-        return memberService.checkVerificationPassword(userDetails,password);
+    public CommonResponse<?> checkVerificationPassword(@AuthenticationPrincipal CustomUserDetails userDetails, @RequestBody MemberRequest.CheckPassword password) {
+        return memberService.checkVerificationPassword(userDetails, password);
     }
 
     @Override
@@ -77,22 +78,22 @@ public class MemberController implements MemberApiSpec {
     @PutMapping("/change-password")
     public CommonResponse<?> changePassword(@AuthenticationPrincipal CustomUserDetails userDetails,
                                             @RequestBody @Valid MemberRequest.CheckPassword password) {
-        return memberService.changePassword(userDetails,password);
+        return memberService.changePassword(userDetails, password);
     }
 
     @Override
     @PutMapping("/change-email")
     public CommonResponse<?> changeEmail(@AuthenticationPrincipal CustomUserDetails userDetails,
                                          @RequestBody MemberRequest.CheckEmail email,
-                                         HttpServletRequest request,HttpServletResponse response) {
-        return memberService.changeEmail(userDetails,email,response,request);
+                                         HttpServletRequest request, HttpServletResponse response) {
+        return memberService.changeEmail(userDetails, email, response, request);
     }
 
     @Override
     @PutMapping("/change-message")
     public CommonResponse<?> changeMessage(@AuthenticationPrincipal CustomUserDetails userDetails,
                                            @RequestBody @Valid MemberRequest.CheckMessage message) {
-        return memberService.changeMessage(userDetails,message);
+        return memberService.changeMessage(userDetails, message);
     }
 
 
@@ -131,11 +132,17 @@ public class MemberController implements MemberApiSpec {
 
     @Override
     @PostMapping("/check-code")
-    public CommonResponse<?> checkVerifyCode(@RequestBody @Valid MemberRequest.VerifyCodeCheck request)  {
-        return memberService.checkVerifyCode(request.email(),request.code());
+    public CommonResponse<?> checkVerifyCode(@RequestBody @Valid MemberRequest.VerifyCodeCheck request) {
+        return memberService.checkVerifyCode(request.email(), request.code());
     }
 
-
+    @PostMapping("/profile")
+    public CommonResponse<?> updateProfile(@AuthenticationPrincipal CustomUserDetails userDetails,
+                                           @RequestPart MultipartFile file) {
+        Member member = userDetails.member();
+        memberService.updateProfile(member, file);
+        return CommonResponse.success();
+    }
 
 
 }

--- a/src/main/java/today/todaysentence/domain/member/service/MemberService.java
+++ b/src/main/java/today/todaysentence/domain/member/service/MemberService.java
@@ -13,6 +13,7 @@ import org.springframework.security.core.context.SecurityContextHolder;
 import org.springframework.security.crypto.password.PasswordEncoder;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
+import org.springframework.web.multipart.MultipartFile;
 import today.todaysentence.domain.bookmark.repository.BookmarkRepository;
 import today.todaysentence.domain.post.Category;
 import today.todaysentence.domain.comment.repository.CommentRepository;
@@ -29,6 +30,7 @@ import today.todaysentence.domain.member.repository.WithdrawRepository;
 import today.todaysentence.domain.post.Post;
 import today.todaysentence.domain.post.repository.PostRepository;
 import today.todaysentence.domain.post.repository.PostRepositoryCustom;
+import today.todaysentence.global.aws.S3Service;
 import today.todaysentence.util.email.EmailSenderService;
 import today.todaysentence.global.exception.exception.BaseException;
 import today.todaysentence.global.exception.exception.ExceptionCode;
@@ -65,6 +67,8 @@ public class MemberService {
     private final RedisService redisService;
     private final JwtUtil jwtUtil;
     private final AuthenticationManagerBuilder authenticationManagerBuilder;
+
+    private final S3Service s3Service;
 
     private static final String EMAIL_TYPE = "EMAIL";
     private static final String NICKNAME_TYPE = "NICKNAME";
@@ -416,7 +420,14 @@ public class MemberService {
         return  postRepositoryCustom.checkInteraction(postId,memberId);
     }
 
+    @Transactional
+    public void updateProfile(Member member, MultipartFile file){
+        if (!member.isDefaultProfile()) {
+            s3Service.remove(member.getProfileImg());
+        }
 
-
+        String newProfileUrl = s3Service.upload(file);
+        member.changeProfile(newProfileUrl);
+    }
 }
 

--- a/src/main/java/today/todaysentence/global/aws/S3Config.java
+++ b/src/main/java/today/todaysentence/global/aws/S3Config.java
@@ -11,13 +11,13 @@ import org.springframework.context.annotation.Configuration;
 @Configuration
 public class S3Config {
 
-    @Value("${spring.cloud.aws.credentials.access-key}")
+    @Value("${cloud.aws.credentials.access-key}")
     private String accessKey;
 
-    @Value("${spring.cloud.aws.credentials.secret-key}")
+    @Value("${cloud.aws.credentials.secret-key}")
     private String secretKey;
 
-    @Value("${spring.cloud.aws.region.static}")
+    @Value("${cloud.aws.region.static}")
     private String region;
 
     @Bean

--- a/src/main/java/today/todaysentence/global/aws/S3Config.java
+++ b/src/main/java/today/todaysentence/global/aws/S3Config.java
@@ -1,0 +1,31 @@
+package today.todaysentence.global.aws;
+
+import com.amazonaws.auth.AWSStaticCredentialsProvider;
+import com.amazonaws.auth.BasicAWSCredentials;
+import com.amazonaws.services.s3.AmazonS3;
+import com.amazonaws.services.s3.AmazonS3ClientBuilder;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+
+@Configuration
+public class S3Config {
+
+    @Value("${spring.cloud.aws.credentials.access-key}")
+    private String accessKey;
+
+    @Value("${spring.cloud.aws.credentials.secret-key}")
+    private String secretKey;
+
+    @Value("${spring.cloud.aws.region.static}")
+    private String region;
+
+    @Bean
+    public AmazonS3 amazonS3() {
+        BasicAWSCredentials awsCredentials = new BasicAWSCredentials(accessKey, secretKey);
+        return AmazonS3ClientBuilder.standard()
+                .withRegion(region)
+                .withCredentials(new AWSStaticCredentialsProvider(awsCredentials))
+                .build();
+    }
+}

--- a/src/main/java/today/todaysentence/global/aws/S3Service.java
+++ b/src/main/java/today/todaysentence/global/aws/S3Service.java
@@ -1,0 +1,76 @@
+package today.todaysentence.global.aws;
+
+import com.amazonaws.services.s3.AmazonS3;
+import com.amazonaws.services.s3.model.CannedAccessControlList;
+import com.amazonaws.services.s3.model.PutObjectRequest;
+import lombok.RequiredArgsConstructor;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.stereotype.Service;
+import org.springframework.web.multipart.MultipartFile;
+import today.todaysentence.global.exception.exception.BaseException;
+import today.todaysentence.global.exception.exception.ExceptionCode;
+
+import java.io.File;
+import java.io.FileOutputStream;
+import java.io.IOException;
+import java.util.Objects;
+import java.util.Optional;
+import java.util.UUID;
+
+import static today.todaysentence.global.exception.exception.ExceptionCode.FAILED_CONVERT_FILE;
+
+@Service
+@RequiredArgsConstructor
+public class S3Service {
+    private final AmazonS3 s3Client;
+
+    @Value("${cloud.aws.s3.bucket}")
+    private String bucketName;
+
+    public String upload(MultipartFile multipartFile) {
+        File file = convertToFile(multipartFile)
+                .orElseThrow(() -> new BaseException(FAILED_CONVERT_FILE));
+
+        return uploadFile(file);
+    }
+
+    private Optional<File> convertToFile(MultipartFile multipartFile) {
+        try {
+            File file = new File(Objects.requireNonNull(multipartFile.getOriginalFilename()));
+
+            if (!file.createNewFile()) {
+                throw new IOException("파일 변환 실패");
+            }
+
+            try (FileOutputStream fos = new FileOutputStream(file)) {
+                fos.write(multipartFile.getBytes());
+            }
+
+            return Optional.of(file);
+        } catch (IOException e) {
+            throw new BaseException(FAILED_CONVERT_FILE);
+        }
+    }
+
+    private String uploadFile(File file) {
+        String fileName = makeFileName(file);
+
+        s3Client.putObject(new PutObjectRequest(bucketName, fileName, fileName)
+                .withCannedAcl(CannedAccessControlList.PublicRead));
+
+        file.delete();
+        return s3Client.getUrl(bucketName, fileName).toString();
+    }
+
+    private String makeFileName(File file) {
+        return UUID.randomUUID() + file.getName();
+    }
+
+    public void remove(String profileUrl) {
+        if (!s3Client.doesObjectExist(bucketName, profileUrl)) {
+            return;
+        }
+
+        s3Client.deleteObject(bucketName, profileUrl);
+    }
+}

--- a/src/main/java/today/todaysentence/global/exception/exception/ExceptionCode.java
+++ b/src/main/java/today/todaysentence/global/exception/exception/ExceptionCode.java
@@ -4,7 +4,9 @@ import lombok.Getter;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.HttpStatus;
 
-import static org.springframework.http.HttpStatus.*;
+import static org.springframework.http.HttpStatus.BAD_REQUEST;
+import static org.springframework.http.HttpStatus.NOT_FOUND;
+import static org.springframework.http.HttpStatus.UNAUTHORIZED;
 
 @Getter
 @RequiredArgsConstructor
@@ -33,7 +35,10 @@ public enum ExceptionCode {
     MEMBER_ALREADY_WITHDRAWN("이미 탈퇴한 회원입니다.",BAD_REQUEST ),
 
     //search
-    NOT_MATCHED_TYPE_PARAMETER("검색 타입이 일치하지않습니다.",BAD_REQUEST);
+    NOT_MATCHED_TYPE_PARAMETER("검색 타입이 일치하지않습니다.",BAD_REQUEST),
+
+    FAILED_CONVERT_FILE("프로필 파일 변경 로직에 문제 발생", HttpStatus.INTERNAL_SERVER_ERROR),
+    ;
 
     private final String message;
     private final HttpStatus status;

--- a/src/main/java/today/todaysentence/global/swagger/MemberApiSpec.java
+++ b/src/main/java/today/todaysentence/global/swagger/MemberApiSpec.java
@@ -10,6 +10,7 @@ import jakarta.mail.MessagingException;
 import jakarta.servlet.http.HttpServletRequest;
 import jakarta.servlet.http.HttpServletResponse;
 import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.multipart.MultipartFile;
 import today.todaysentence.domain.member.dto.MemberRequest;
 import today.todaysentence.domain.member.dto.MemberResponse;
 import today.todaysentence.global.response.CommonResponse;
@@ -329,7 +330,9 @@ public interface MemberApiSpec {
     })
     CommonResponse<?> findPassword(MemberRequest.CheckEmail email) throws MessagingException;
 
-
+    @Operation(summary = "프로필 사진 변경")
+    @ApiResponse(responseCode = "200", content = @Content(mediaType = "multipart/form-data"))
+    CommonResponse<?> updateProfile(CustomUserDetails user, MultipartFile file);
 
 
 


### PR DESCRIPTION
s3 업로드하고 Member의 profileImg 필드에 넣는 기능 추가했습니다!

조회하는 건 MemberService.getMemberInfo() 메서드 통해서 되니 따로 안 만들었습니다.

MultfilpartFile -> File로 변환하고 s3에 업로드, file 삭제, url 받아와 멤버 엔티티에 수정하는 플로우입니다.
