### PR TITLE
명언 글 수정 및 삭제 기능 추가

### DIFF
--- a/src/main/java/today/todaysentence/domain/member/Member.java
+++ b/src/main/java/today/todaysentence/domain/member/Member.java
@@ -4,7 +4,6 @@ import jakarta.persistence.*;
 import lombok.*;
 import today.todaysentence.global.timeStamped.Timestamped;
 
-import java.time.LocalDate;
 import java.time.LocalDateTime;
 import java.util.UUID;
 
@@ -82,11 +81,9 @@ public class Member extends Timestamped {
         return this.isSocialMember;
     }
 
-
     public boolean isDefaultProfile() {
         return DEFAULT_PROFILE_IMG_URL.equals(profileImg);
     }
-
 
     public void changeProfile(String profileUrl) {
         this.profileImg = profileUrl;

--- a/src/main/java/today/todaysentence/domain/member/service/MemberService.java
+++ b/src/main/java/today/todaysentence/domain/member/service/MemberService.java
@@ -167,7 +167,7 @@ public class MemberService {
 
         String originEmail = member.getEmail();
 
-        List<Post> wMemberPosts =postRepository.findByWriter(member);
+        List<Post> wMemberPosts =postRepository.findByWriterAndDeletedAtIsNull(member);
         List<Long> postIds = wMemberPosts.stream()
                 .map(Post::getId)
                 .toList();

--- a/src/main/java/today/todaysentence/domain/post/Post.java
+++ b/src/main/java/today/todaysentence/domain/post/Post.java
@@ -64,6 +64,20 @@ public class Post extends Timestamped {
                 .toList();
     }
 
+    public boolean isWrittenBy(Member member) {
+        return this.writer.equals(member);
+    }
+
+    public void update(Book book,
+                       Category category,
+                       List<Hashtag> hashtags,
+                       String content) {
+        this.book = book;
+        this.category = category;
+        this.hashtags = hashtags;
+        this.content = content;
+    }
+
     public void deleted(){
         this.deletedAt= LocalDateTime.now();
     }

--- a/src/main/java/today/todaysentence/domain/post/Post.java
+++ b/src/main/java/today/todaysentence/domain/post/Post.java
@@ -78,8 +78,8 @@ public class Post extends Timestamped {
         this.content = content;
     }
 
-    public void deleted(){
-        this.deletedAt= LocalDateTime.now();
+    public void delete(){
+        this.deletedAt = LocalDateTime.now();
     }
 
     public void incrementLikeCount(){this.likeCount++;}

--- a/src/main/java/today/todaysentence/domain/post/api/PostController.java
+++ b/src/main/java/today/todaysentence/domain/post/api/PostController.java
@@ -8,13 +8,13 @@ import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.PutMapping;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.ResponseStatus;
 import org.springframework.web.bind.annotation.RestController;
 import today.todaysentence.domain.member.Member;
-import today.todaysentence.domain.member.repository.MemberRepository;
 import today.todaysentence.domain.member.service.MemberService;
 import today.todaysentence.domain.post.dto.PostRequest;
 import today.todaysentence.domain.post.dto.PostResponse;
@@ -63,6 +63,16 @@ public class PostController implements PostApiSpec {
     @GetMapping("/{post_id}")
     public CommonResponse<PostResponse.Detail> getPostDetail(@PathVariable("post_id") Long postId) {
         return CommonResponse.ok(postService.getPostDetail(postId));
+    }
+
+    @ResponseStatus(HttpStatus.NO_CONTENT)
+    @PutMapping("/{post_id}")
+    public CommonResponse<?> modifyPost(@AuthenticationPrincipal CustomUserDetails userDetails,
+                                        @PathVariable("post_id") Long postId,
+                                        @Valid @RequestBody PostRequest.Record request) {
+        Member member = userDetails.member();
+        postService.modify(request, member, postId);
+        return CommonResponse.success();
     }
 
     @GetMapping("/test/{post_id}")

--- a/src/main/java/today/todaysentence/domain/post/api/PostController.java
+++ b/src/main/java/today/todaysentence/domain/post/api/PostController.java
@@ -5,6 +5,7 @@ import lombok.RequiredArgsConstructor;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
+import org.springframework.web.bind.annotation.DeleteMapping;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PostMapping;
@@ -72,6 +73,14 @@ public class PostController implements PostApiSpec {
                                         @Valid @RequestBody PostRequest.Record request) {
         Member member = userDetails.member();
         postService.modify(request, member, postId);
+        return CommonResponse.success();
+    }
+
+    @DeleteMapping("/{post_id}")
+    public CommonResponse<?> deletePost(@AuthenticationPrincipal CustomUserDetails userDetails,
+                                        @PathVariable("post_id") Long postId) {
+        Member member = userDetails.member();
+        postService.delete(member, postId);
         return CommonResponse.success();
     }
 

--- a/src/main/java/today/todaysentence/domain/post/repository/PostRepository.java
+++ b/src/main/java/today/todaysentence/domain/post/repository/PostRepository.java
@@ -16,22 +16,22 @@ import java.util.Set;
 
 public interface PostRepository extends JpaRepository<Post, Long> {
 
-    @Query("SELECT p FROM Post p WHERE p.writer = :member AND p.createAt BETWEEN :startDate AND :endDate")
+    @Query("SELECT p FROM Post p WHERE p.deletedAt IS NULL AND p.writer = :member AND p.createAt BETWEEN :startDate AND :endDate")
     List<Post> findMyPostsByDate(@Param("member")Member member,
                                  @Param("startDate") LocalDateTime startDate,
                                  @Param("endDate") LocalDateTime endDate);
 
-    Optional<Post> findById(@NonNull Long id);
+    Optional<Post> findByIdAndDeletedAtIsNull(@NonNull Long id);
 
-    List<Post> findByWriter(Member member);
+    List<Post> findByWriterAndDeletedAtIsNull(Member member);
 
-    boolean existsById(@NonNull Long id);
+    boolean existsByIdAndDeletedAtIsNull(@NonNull Long id);
 
     @Query("SELECT new today.todaysentence.domain.post.dto.PostResponse$CategoryCount(" +
             "p.category, COUNT(*)" +
             ")  " +
             "FROM Post p " +
-            "WHERE p.writer.id = :memberId " +
+            "WHERE p.writer.id = :memberId AND p.deletedAt Is NULL " +
             "GROUP BY p.category")
     List<PostResponse.CategoryCount> findByMemberRecordsStatistics(@Param("memberId") Long id);
 
@@ -43,6 +43,7 @@ public interface PostRepository extends JpaRepository<Post, Long> {
                 "(SELECT b.postId " +
                 "FROM Bookmark b " +
                 "WHERE b.member.id = :memberId AND b.isSaved = true ) " +
+            "AND p.deletedAt IS NULL " +
             "GROUP BY p.category")
     List<PostResponse.CategoryCount> findByMemberBookmarksStatistics(@Param("memberId") Long id);
 
@@ -51,11 +52,11 @@ public interface PostRepository extends JpaRepository<Post, Long> {
       FROM post p
       WHERE p.category = :category
       AND p.id NOT IN :duplicatedIds
+      AND p.deletedAt IS NULL
       ORDER BY RAND()
       LIMIT :count
       """, nativeQuery = true)
     List<Post> findRandomPostsByCategoryAndNotInIds(String category, Set<Long> duplicatedIds, int count);
-
 
     @Query("SELECT new today.todaysentence.domain.post.dto.PostResponse$CategoryCount(" +
           "p.category,SUM(" +
@@ -71,9 +72,9 @@ public interface PostRepository extends JpaRepository<Post, Long> {
           "                 END)" +
           ")" +
           "FROM Post p " +
+            "WHERE p.deletedAt IS NULL " +
           "GROUP BY p.category")
     List<PostResponse.CategoryCount> findByMemberAllStatistics(@Param("memberId") Long memberId);
-
 
     @Modifying
     @Query("UPDATE Post p SET p.deletedAt = CURRENT_TIMESTAMP WHERE p.id IN :postIds")

--- a/src/main/java/today/todaysentence/domain/post/repository/PostRepositoryCustom.java
+++ b/src/main/java/today/todaysentence/domain/post/repository/PostRepositoryCustom.java
@@ -93,7 +93,7 @@ public class PostRepositoryCustom {
                 "INNER JOIN book b ON b.isbn = p.book_isbn " +
                 "INNER JOIN post_hashtag ph ON ph.post_id = p.id " +
                 "LEFT JOIN hashtag h ON h.id = ph.hashtag_id " +
-                "WHERE " + query + " " +
+                "WHERE " + query + " AND p.deleted_at IS NULL " +
                 "GROUP BY p.id " +
                 "ORDER BY like_count DESC " +
                 "limit 1";
@@ -114,7 +114,7 @@ public class PostRepositoryCustom {
                 "FROM post p " +
                 "LEFT JOIN likes l ON l.post_id = p.id AND l.member_id = :memberId " +
                 "LEFT JOIN bookmark bm ON bm.post_id = p.id AND bm.member_id = :memberId " +
-                "WHERE p.id IN :postIds " +
+                "WHERE p.id IN :postIds " + " AND p.deleted_at IS NULL " +
                 "GROUP BY p.id " +
                 "ORDER BY FIELD(p.id, " + postIdsString + ")";
 
@@ -132,7 +132,7 @@ public class PostRepositoryCustom {
                 "FROM post p " +
                 "LEFT JOIN likes l ON l.post_id = p.id AND l.member_id = :memberId " +
                 "LEFT JOIN bookmark bm ON bm.post_id = p.id AND bm.member_id = :memberId " +
-                "WHERE p.id = :postId " +
+                "WHERE p.id = :postId " + " AND p.deleted_at IS NULL " +
                 "GROUP BY p.id";
 
         Query nativeQuery = entityManager.createNativeQuery(sql, InteractionResponseDTO.class);
@@ -153,8 +153,6 @@ public class PostRepositoryCustom {
         countNativeQuery.setParameter("search",search);
 
         return  (Long) countNativeQuery.getSingleResult();
-
-
     }
 
     public PostCategoryLikeCountDTO findPostCategoryAndLikeCount(Long postId) {
@@ -162,7 +160,7 @@ public class PostRepositoryCustom {
                 "p.category, " +
                 "p.like_count " +
                 "FROM post p " +
-                "WHERE p.id = :postId " +
+                "WHERE p.id = :postId " + " AND p.deleted_at IS NULL " +
                 "GROUP BY p.id ";
 
         Query nativeQuery = entityManager.createNativeQuery(query, PostCategoryLikeCountDTO.class);

--- a/src/main/java/today/todaysentence/domain/post/service/PostService.java
+++ b/src/main/java/today/todaysentence/domain/post/service/PostService.java
@@ -21,7 +21,6 @@ import today.todaysentence.domain.post.dto.ScheduledPosts;
 import today.todaysentence.domain.post.repository.PostQueryRepository;
 import today.todaysentence.domain.post.repository.PostRepository;
 import today.todaysentence.domain.post.repository.PostRepositoryCustom;
-import today.todaysentence.global.exception.exception.BaseException;
 import today.todaysentence.global.exception.exception.ExceptionCode;
 import today.todaysentence.global.exception.exception.PostException;
 import today.todaysentence.global.response.CommonResponse;
@@ -31,7 +30,6 @@ import today.todaysentence.global.security.userDetails.JwtUserDetails;
 import java.time.LocalDateTime;
 import java.util.*;
 import java.util.concurrent.ThreadLocalRandom;
-import java.util.concurrent.TimeUnit;
 import java.util.stream.Collectors;
 import java.util.stream.IntStream;
 import java.util.stream.Stream;
@@ -96,12 +94,12 @@ public class PostService {
     }
 
     private Post findPost(Long postId) {
-        return postRepository.findById(postId)
+        return postRepository.findByIdAndDeletedAtIsNull(postId)
                 .orElseThrow(() -> new PostException(ExceptionCode.POST_NOT_FOUND));
     }
 
     public void isValidPost(Long postId) {
-        if (postRepository.existsById(postId)) {
+        if (postRepository.existsByIdAndDeletedAtIsNull(postId)) {
             return;
         }
 
@@ -120,6 +118,17 @@ public class PostService {
         List<Hashtag> hashtags = hashtagService.findOrCreate(request.hashtags());
 
         post.update(book, request.category(), hashtags, request.content());
+    }
+
+    @Transactional
+    public void delete(Member member, Long postId) {
+        Post post = findPost(postId);
+
+        if (!post.isWrittenBy(member)) {
+            throw new PostException(ExceptionCode.POST_NOT_MATCHED_WRITER);
+        }
+
+        post.delete();
     }
 
     @Transactional(readOnly = true)

--- a/src/main/java/today/todaysentence/domain/post/service/PostService.java
+++ b/src/main/java/today/todaysentence/domain/post/service/PostService.java
@@ -108,6 +108,19 @@ public class PostService {
         throw new PostException(ExceptionCode.POST_NOT_FOUND);
     }
 
+    @Transactional
+    public void modify(PostRequest.Record request, Member member, Long postId) {
+        Post post = findPost(postId);
+
+        if (!post.isWrittenBy(member)) {
+            throw new PostException(ExceptionCode.POST_NOT_MATCHED_WRITER);
+        }
+
+        Book book = bookService.findOrCreate(PostMapper.toBook(request));
+        List<Hashtag> hashtags = hashtagService.findOrCreate(request.hashtags());
+
+        post.update(book, request.category(), hashtags, request.content());
+    }
 
     @Transactional(readOnly = true)
     public CommonResponse<PostResponse.Statistics> getStatistics(JwtUserDetails userDetails) {

--- a/src/main/java/today/todaysentence/global/exception/exception/ExceptionCode.java
+++ b/src/main/java/today/todaysentence/global/exception/exception/ExceptionCode.java
@@ -5,6 +5,7 @@ import lombok.RequiredArgsConstructor;
 import org.springframework.http.HttpStatus;
 
 import static org.springframework.http.HttpStatus.BAD_REQUEST;
+import static org.springframework.http.HttpStatus.FORBIDDEN;
 import static org.springframework.http.HttpStatus.NOT_FOUND;
 import static org.springframework.http.HttpStatus.UNAUTHORIZED;
 
@@ -24,6 +25,7 @@ public enum ExceptionCode {
 
     // post
     POST_NOT_FOUND("게시된 명언 글을 찾을 수 없습니다.", NOT_FOUND),
+    POST_NOT_MATCHED_WRITER("글을 작성한 본인이 아닙니다.", FORBIDDEN),
 
     //
     PARAMETER_VALIDATION_FAIL("파라미터가 올바르지 않습니다.", BAD_REQUEST),

--- a/src/main/java/today/todaysentence/global/swagger/PostApiSpec.java
+++ b/src/main/java/today/todaysentence/global/swagger/PostApiSpec.java
@@ -102,7 +102,6 @@ public interface PostApiSpec {
                                                                                 int month,
                                                                                 int year);
 
-
     @Operation(summary = "명언 글 상세조회하기")
     @ApiResponses({
             @ApiResponse(responseCode = "200", content = @Content(mediaType = "application/json", examples = {
@@ -140,6 +139,11 @@ public interface PostApiSpec {
     CommonResponse<?> modifyPost(CustomUserDetails userDetails,
                                  Long postId,
                                  PostRequest.Record request);
+
+    @Operation(summary = "명언 글 삭제")
+    @ApiResponse(responseCode = "200", description = "삭제 성공")
+    CommonResponse<?> deletePost(CustomUserDetails userDetails,
+                                 Long postId);
 
     @Operation(summary = "통계 조회")
     @ApiResponses({

--- a/src/main/java/today/todaysentence/global/swagger/PostApiSpec.java
+++ b/src/main/java/today/todaysentence/global/swagger/PostApiSpec.java
@@ -56,7 +56,7 @@ public interface PostApiSpec {
                                                                          "bookPublishingYear": 2007,
                                                                          "bookCover": "http://coverurl.com/bookurl",
                                                                          "isbn": "1234567890abc",
-                                                                         "category": "시/소설/에세이",
+                                                                         "category": "POEM_NOVEL_ESSAY",
                                                                          "hashtags": [
                                                                               "우주", "통일의법칙", "신기"
                                                                          ],
@@ -135,7 +135,11 @@ public interface PostApiSpec {
     })
     CommonResponse<PostResponse.Detail> getPostDetail(Long post_id);
 
-
+    @Operation(summary = "명언 글 수정")
+    @ApiResponse(responseCode = "204", description = "수정 성공")
+    CommonResponse<?> modifyPost(CustomUserDetails userDetails,
+                                 Long postId,
+                                 PostRequest.Record request);
 
     @Operation(summary = "통계 조회")
     @ApiResponses({

--- a/src/main/java/today/todaysentence/global/timeStamped/Timestamped.java
+++ b/src/main/java/today/todaysentence/global/timeStamped/Timestamped.java
@@ -10,6 +10,7 @@ import lombok.experimental.SuperBuilder;
 import org.springframework.data.annotation.CreatedDate;
 import org.springframework.data.annotation.LastModifiedDate;
 import org.springframework.data.jpa.domain.support.AuditingEntityListener;
+import today.todaysentence.domain.member.Member;
 
 import java.time.LocalDateTime;
 
@@ -19,7 +20,7 @@ import java.time.LocalDateTime;
 @NoArgsConstructor
 @AllArgsConstructor
 @EntityListeners(AuditingEntityListener.class)
-public class Timestamped {
+public abstract class Timestamped {
     @CreatedDate
     private LocalDateTime createAt;
 


### PR DESCRIPTION
변경된 파일이 많아서 커밋으로 파일 변경 내역 파악하시는 게 편하실 수도 있습니다!

## 1. Member 동등성 검사 로직 고려 필요(equals, hashCode)
수정 및 삭제할 때에 요청자와 글 작성자가 일치하는지 확인을 위해 Member 동등성 검사를 위해 equals 메서드를 사용해야 할 것 같은데
현재는 롬복으로 달아두셨더라구요. equals랑 hashCode 재정의를 해야할 것 같은데 의견 나누어봐야할 것 같아용..

## 2. 쿼리에 글 삭제 조건 추가
Post 조회 쿼리들에 삭제 조건을 추가하긴 했습니다. 다 추가한다고 했는데 혹시 빠뜨린 부분이 있을 수도 있어서 보시다가 누락된 부분 말씀해주시면 추가하겠습니다!!

## 3. 글 수정 형태
어떻게 수정한다는 말이 따로 없어서 일단은 PutMapping으로 해서 글 전체가 수정되도록 만들어놨습니다. content만 수정한다, category는 수정하지 않는다 와 같은 포맷을 몰라서 일단은 모든 필드로 넘겨받도록 만들었는데, UI 쪽 보고 변경사항 있으면 수정해야할 것 같아요.