### PR TITLE
카테고리 별 기록/저장 목록 조회 기능 추가

### DIFF
--- a/src/main/java/today/todaysentence/domain/bookmark/api/BookmarkController.java
+++ b/src/main/java/today/todaysentence/domain/bookmark/api/BookmarkController.java
@@ -15,9 +15,11 @@ import today.todaysentence.domain.bookmark.dto.BookmarkRequest;
 import today.todaysentence.domain.bookmark.dto.BookmarkResponse;
 import today.todaysentence.domain.bookmark.service.BookmarkService;
 import today.todaysentence.domain.member.Member;
+import today.todaysentence.domain.post.Category;
 import today.todaysentence.domain.post.dto.PostResponse;
 import today.todaysentence.global.response.CommonResponse;
 import today.todaysentence.global.security.userDetails.CustomUserDetails;
+import today.todaysentence.global.security.userDetails.JwtUserDetails;
 import today.todaysentence.global.swagger.BookmarkApiSpec;
 
 import java.util.List;
@@ -46,5 +48,12 @@ public class BookmarkController implements BookmarkApiSpec {
         }
 
         return ResponseEntity.ok(CommonResponse.ok(bookmarks));
+    }
+
+    @GetMapping("/api/posts/bookmarks/statistics")
+    public CommonResponse<BookmarkResponse.CategoryStatistics> getBookmarksByCategory(@AuthenticationPrincipal CustomUserDetails userDetails,
+                                                   @RequestParam("category")Category category) {
+        Member member = userDetails.member();
+        return CommonResponse.ok(bookmarkService.getBookmarksByCategory(member, category));
     }
 }

--- a/src/main/java/today/todaysentence/domain/bookmark/dto/BookmarkResponse.java
+++ b/src/main/java/today/todaysentence/domain/bookmark/dto/BookmarkResponse.java
@@ -2,6 +2,8 @@ package today.todaysentence.domain.bookmark.dto;
 
 import com.fasterxml.jackson.annotation.JsonInclude;
 
+import java.util.List;
+
 public class BookmarkResponse {
 
     @JsonInclude(JsonInclude.Include.NON_NULL)
@@ -14,5 +16,20 @@ public class BookmarkResponse {
         public static SavedStatus cancel() {
             return new SavedStatus(false, null, null);
         }
+    }
+
+    public record CategoryStatistic(
+            Long postId,
+            String bookTitle,
+            String bookAuthor,
+            Integer bookmarkMonth,
+            Integer bookmarkDay
+    ) {
+    }
+
+    public record CategoryStatistics(
+            Long totalBookmarkCount,
+            List<CategoryStatistic> statistics
+    ) {
     }
 }

--- a/src/main/java/today/todaysentence/domain/bookmark/repository/BookmarkQueryRepository.java
+++ b/src/main/java/today/todaysentence/domain/bookmark/repository/BookmarkQueryRepository.java
@@ -1,0 +1,63 @@
+package today.todaysentence.domain.bookmark.repository;
+
+import com.querydsl.core.types.Projections;
+import com.querydsl.jpa.impl.JPAQueryFactory;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Repository;
+import today.todaysentence.domain.book.QBook;
+import today.todaysentence.domain.bookmark.QBookmark;
+import today.todaysentence.domain.bookmark.dto.BookmarkResponse;
+import today.todaysentence.domain.member.Member;
+import today.todaysentence.domain.post.Category;
+import today.todaysentence.domain.post.QPost;
+
+import java.util.List;
+
+@Repository
+@RequiredArgsConstructor
+public class BookmarkQueryRepository {
+    private final JPAQueryFactory queryFactory;
+
+    public BookmarkResponse.CategoryStatistics findBookmarksByCategory(Member member, Category category) {
+        QBookmark bookmark = QBookmark.bookmark;
+        QPost post = QPost.post;
+        QBook book = QBook.book;
+
+        List<BookmarkResponse.CategoryStatistic> statistics = queryFactory
+                .select(Projections.constructor(BookmarkResponse.CategoryStatistic.class,
+                        post.id,
+                        book.title,
+                        book.author,
+                        bookmark.modifiedAt.month(),
+                        bookmark.modifiedAt.dayOfMonth()
+                ))
+                .from(bookmark)
+                .join(post).on(bookmark.postId.eq(post.id))
+                .join(post.book, book)
+                .where(
+                        bookmark.member.eq(member),
+                        post.category.eq(category),
+                        post.deletedAt.isNull(),
+                        bookmark.isSaved.isTrue()
+                )
+                .orderBy(bookmark.modifiedAt.desc())
+                .fetch();
+
+        Long totalCount = queryFactory
+                .select(bookmark.id.count())
+                .from(bookmark)
+                .join(post).on(bookmark.postId.eq(post.id))
+                .where(
+                        bookmark.member.eq(member),
+                        post.category.eq(category),
+                        post.deletedAt.isNull(),
+                        bookmark.isSaved.isTrue()
+                )
+                .fetchOne();
+
+        return new BookmarkResponse.CategoryStatistics(
+                totalCount,
+                statistics
+        );
+    }
+}

--- a/src/main/java/today/todaysentence/domain/bookmark/service/BookmarkService.java
+++ b/src/main/java/today/todaysentence/domain/bookmark/service/BookmarkService.java
@@ -6,8 +6,10 @@ import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 import today.todaysentence.domain.bookmark.Bookmark;
 import today.todaysentence.domain.bookmark.dto.BookmarkResponse;
+import today.todaysentence.domain.bookmark.repository.BookmarkQueryRepository;
 import today.todaysentence.domain.bookmark.repository.BookmarkRepository;
 import today.todaysentence.domain.member.Member;
+import today.todaysentence.domain.post.Category;
 import today.todaysentence.domain.post.EventType;
 import today.todaysentence.domain.post.dto.PostResponse;
 import today.todaysentence.domain.post.service.PostService;
@@ -20,6 +22,7 @@ public class BookmarkService {
 
     private final PostService postService;
     private final BookmarkRepository bookmarkRepository;
+    private final BookmarkQueryRepository bookmarkQueryRepository;
     private final ApplicationEventPublisher eventPublisher;
 
     @Transactional
@@ -47,5 +50,10 @@ public class BookmarkService {
                 .map(Bookmark::getPostId)
                 .map(postService::toSummary)
                 .toList();
+    }
+
+    @Transactional(readOnly = true)
+    public BookmarkResponse.CategoryStatistics getBookmarksByCategory(Member member, Category category) {
+        return bookmarkQueryRepository.findBookmarksByCategory(member, category);
     }
 }

--- a/src/main/java/today/todaysentence/domain/post/api/PostController.java
+++ b/src/main/java/today/todaysentence/domain/post/api/PostController.java
@@ -17,6 +17,7 @@ import org.springframework.web.bind.annotation.ResponseStatus;
 import org.springframework.web.bind.annotation.RestController;
 import today.todaysentence.domain.member.Member;
 import today.todaysentence.domain.member.service.MemberService;
+import today.todaysentence.domain.post.Category;
 import today.todaysentence.domain.post.dto.PostRequest;
 import today.todaysentence.domain.post.dto.PostResponse;
 import today.todaysentence.domain.post.dto.PostResponseDTO;
@@ -34,7 +35,7 @@ import java.util.List;
 @RestController
 public class PostController implements PostApiSpec {
     private final PostService postService;
-    
+
     //테스트용으로 실배포시 삭제
     private final PostRepositoryCustom postRepositoryCustom;
     private final MemberService memberService;
@@ -49,8 +50,8 @@ public class PostController implements PostApiSpec {
 
     @GetMapping("/records")
     public ResponseEntity<CommonResponse<List<PostResponse.Summary>>> getMyPostsByDate(@AuthenticationPrincipal CustomUserDetails userDetails,
-                                                                                      @RequestParam("month") int month,
-                                                                                      @RequestParam("year") int year) {
+                                                                                       @RequestParam("month") int month,
+                                                                                       @RequestParam("year") int year) {
         Member member = userDetails.member();
         List<PostResponse.Summary> posts = postService.getMyPostsByDate(member, month, year);
 
@@ -86,24 +87,28 @@ public class PostController implements PostApiSpec {
 
     @GetMapping("/test/{post_id}")
     public CommonResponse<?> test(@AuthenticationPrincipal JwtUserDetails userDetails,
-            @PathVariable("post_id") Long postId) {
+                                  @PathVariable("post_id") Long postId) {
 
         String query = "p.id = " + postId;
         PostResponseDTO result = postRepositoryCustom.findPostByDynamicQuery(query);
-        PostResponse.PostResult testDto = new PostResponse.PostResult(result,memberService.checkInteraction(postId, userDetails.id()));
+        PostResponse.PostResult testDto = new PostResponse.PostResult(result, memberService.checkInteraction(postId, userDetails.id()));
         return CommonResponse.ok(testDto);
     }
 
     @GetMapping("/statistics")
-    public CommonResponse<PostResponse.Statistics> getStatistics(@AuthenticationPrincipal JwtUserDetails userDetails){
+    public CommonResponse<PostResponse.Statistics> getStatistics(@AuthenticationPrincipal JwtUserDetails userDetails) {
         return postService.getStatistics(userDetails);
     }
 
     @GetMapping("/today-sentence")
-    public CommonResponse<PostResponse.PostResult> getTodaySentence(@AuthenticationPrincipal CustomUserDetails userDetails){
+    public CommonResponse<PostResponse.PostResult> getTodaySentence(@AuthenticationPrincipal CustomUserDetails userDetails) {
         return postService.getTodaySentence(userDetails);
     }
 
-
-
+    @GetMapping("/records/statistics")
+    public CommonResponse<PostResponse.CategoryStatistics> getRecordsByCategory(@AuthenticationPrincipal CustomUserDetails userDetails,
+                                                                                @RequestParam("category") Category category) {
+        Member member = userDetails.member();
+        return CommonResponse.ok(postService.getRecordsByCategory(member, category));
+    }
 }

--- a/src/main/java/today/todaysentence/domain/post/dto/PostResponse.java
+++ b/src/main/java/today/todaysentence/domain/post/dto/PostResponse.java
@@ -1,6 +1,7 @@
 package today.todaysentence.domain.post.dto;
 
 import lombok.Builder;
+import today.todaysentence.domain.bookmark.dto.BookmarkResponse;
 import today.todaysentence.domain.post.Category;
 import today.todaysentence.domain.member.dto.InteractionResponseDTO;
 import today.todaysentence.domain.post.EventType;
@@ -71,4 +72,18 @@ public class PostResponse {
     ){
     }
 
+    public record CategoryStatistic(
+            Long postId,
+            String bookTitle,
+            String bookAuthor,
+            Integer recordMonth,
+            Integer recordDay
+    ) {
+    }
+
+    public record CategoryStatistics(
+            Long totalRecordCount,
+            List<PostResponse.CategoryStatistic> statistics
+    ) {
+    }
 }

--- a/src/main/java/today/todaysentence/domain/post/repository/PostQueryRepository.java
+++ b/src/main/java/today/todaysentence/domain/post/repository/PostQueryRepository.java
@@ -1,12 +1,16 @@
 package today.todaysentence.domain.post.repository;
 
+import com.querydsl.core.types.Projections;
 import com.querydsl.core.types.dsl.Expressions;
 import com.querydsl.jpa.impl.JPAQueryFactory;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Repository;
+import today.todaysentence.domain.book.QBook;
+import today.todaysentence.domain.post.Category;
 import today.todaysentence.domain.post.Post;
 import today.todaysentence.domain.post.QPost;
 import today.todaysentence.domain.member.Member;
+import today.todaysentence.domain.post.dto.PostResponse;
 
 import java.util.List;
 import java.util.Optional;
@@ -68,5 +72,43 @@ public class PostQueryRepository {
                 .fetchFirst();
 
         return Optional.ofNullable(fallbackPost);
+    }
+
+    public PostResponse.CategoryStatistics findRecordsByCategory(Member member, Category category) {
+        QPost post = QPost.post;
+        QBook book = QBook.book;
+
+        List<PostResponse.CategoryStatistic> statistics = queryFactory
+                .select(Projections.constructor(PostResponse.CategoryStatistic.class,
+                        post.id,
+                        book.title,
+                        book.author,
+                        post.modifiedAt.month(),
+                        post.modifiedAt.dayOfMonth()
+                ))
+                .from(post)
+                .join(post.book, book)
+                .where(
+                        post.category.eq(category),
+                        post.deletedAt.isNull(),
+                        post.writer.ne(member)
+                )
+                .orderBy(post.modifiedAt.desc())
+                .fetch();
+
+        Long totalCount = queryFactory
+                .select(post.count())
+                .from(post)
+                .where(
+                        post.category.eq(category),
+                        post.deletedAt.isNull(),
+                        post.writer.ne(member)
+                )
+                .fetchOne();
+
+        return new PostResponse.CategoryStatistics(
+                totalCount,
+                statistics
+        );
     }
 }

--- a/src/main/java/today/todaysentence/domain/post/service/PostService.java
+++ b/src/main/java/today/todaysentence/domain/post/service/PostService.java
@@ -275,6 +275,8 @@ public class PostService {
                 .collect(Collectors.toSet());
     }
 
-
+    public PostResponse.CategoryStatistics getRecordsByCategory(Member member, Category category) {
+        return postQueryRepository.findRecordsByCategory(member, category);
+    }
 
 }

--- a/src/main/java/today/todaysentence/global/swagger/BookmarkApiSpec.java
+++ b/src/main/java/today/todaysentence/global/swagger/BookmarkApiSpec.java
@@ -9,6 +9,8 @@ import io.swagger.v3.oas.annotations.responses.ApiResponses;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import org.springframework.http.ResponseEntity;
 import today.todaysentence.domain.bookmark.dto.BookmarkRequest;
+import today.todaysentence.domain.bookmark.dto.BookmarkResponse;
+import today.todaysentence.domain.post.Category;
 import today.todaysentence.domain.post.dto.PostResponse;
 import today.todaysentence.global.response.CommonResponse;
 import today.todaysentence.global.security.userDetails.CustomUserDetails;
@@ -98,4 +100,44 @@ public interface BookmarkApiSpec {
     ResponseEntity<CommonResponse<List<PostResponse.Summary>>> getMyBookmarksByDate(CustomUserDetails userDetails,
                                                                                     int month,
                                                                                     int year);
+
+    @Operation(summary = "카테고리에 맞는 내가 저장한 명언글 목록 조회하기")
+    @ApiResponses({
+            @ApiResponse(responseCode = "200", content = @Content(mediaType = "application/json", examples = {
+                    @ExampleObject(name = "카테고리 별 저장한 명언글 목록 조회 성공", value = """
+                            {
+                                "data":[
+                                    "totalBookmarkCount":2,
+                                    "statistics":[
+                                        {
+                                            "postId":2,
+                                            "bookTitle":"테스트2책",
+                                            "bookAuthor":"저자2",
+                                            "bookmarkMonth":4,
+                                            "bookmarkDay:21
+                                        },
+                                        {
+                                            "postId":6,
+                                            "bookTitle":"테스트6책",
+                                            "bookAuthor":"저자6",
+                                            "bookmarkMonth":2,
+                                            "bookmarkDay:13
+                                    ]
+                                ]
+                            }
+                            """)
+            })),
+            @ApiResponse(responseCode = "200", content = @Content(mediaType = "application/json", examples = {
+                    @ExampleObject(name = "카테고리에 맞는 저장한 글이 없음", value = """
+                            {
+                                "data":[
+                                    "totalBookmarkCount":0,
+                                    "statistics":[]
+                                ]
+                            }
+                            """)
+            }))
+    })
+    CommonResponse<BookmarkResponse.CategoryStatistics> getBookmarksByCategory(CustomUserDetails userDetails,
+                                                                               Category category);
 }

--- a/src/main/java/today/todaysentence/global/swagger/PostApiSpec.java
+++ b/src/main/java/today/todaysentence/global/swagger/PostApiSpec.java
@@ -9,6 +9,7 @@ import io.swagger.v3.oas.annotations.responses.ApiResponses;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import org.springframework.http.ResponseEntity;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
+import today.todaysentence.domain.post.Category;
 import today.todaysentence.domain.post.dto.PostRequest;
 import today.todaysentence.domain.post.dto.PostResponse;
 import today.todaysentence.domain.post.dto.PostResponseDTO;
@@ -212,4 +213,43 @@ public interface PostApiSpec {
             }))
     })
     CommonResponse<PostResponse.PostResult> getTodaySentence(@AuthenticationPrincipal CustomUserDetails userDetails);
+
+    @Operation(summary = "카테고리에 맞는 나의 기록 목록 조회")
+    @ApiResponses({
+            @ApiResponse(responseCode = "200", content = @Content(mediaType = "application/json", examples = {
+                    @ExampleObject(name = "카테고리 별 기록한 명언글 목록 조회 성공", value = """
+                            {
+                                "data":[
+                                    "totalRecordCount":2,
+                                    "statistics":[
+                                        {
+                                            "postId":2,
+                                            "bookTitle":"테스트2책",
+                                            "bookAuthor":"저자2",
+                                            "bookmarkMonth":4,
+                                            "bookmarkDay:21
+                                        },
+                                        {
+                                            "postId":6,
+                                            "bookTitle":"테스트6책",
+                                            "bookAuthor":"저자6",
+                                            "bookmarkMonth":2,
+                                            "bookmarkDay:13
+                                    ]
+                                ]
+                            }
+                            """)
+            })),
+            @ApiResponse(responseCode = "200", content = @Content(mediaType = "application/json", examples = {
+                    @ExampleObject(name = "카테고리에 맞는 기록 글이 없음", value = """
+                            {
+                                "data":[
+                                    "totalRecordCount":0,
+                                    "statistics":[]
+                                ]
+                            }
+                            """)
+            }))
+    })
+    CommonResponse<PostResponse.CategoryStatistics> getRecordsByCategory(CustomUserDetails userDetails, Category category);
 }


### PR DESCRIPTION
## 카테고리 별 기록/저장 목록 조회 기능

두 개의 흐름 형태는 동일합니다.

PostResponse와 BookmarkResponse에 각각 완전히 동일한 형태의 dto를 만들어서 사용했습니다. 근데 두 개를 상위 모듈로 빼서 통일시키는 게 나을지 그냥 이대로 쓰는 게 맞는지 모르겠네요.. 일단은 따로따로 만들었습니다.

조회 쿼리는 queryDsl로 작성했습니다. 쿼리는 개수 조회하는 쿼리 하나랑 프론트에 리턴해줄 필드만 조회하는 쿼리 하나 만들어서 두 개 합쳐서 넘기는 형태로 했습니다!